### PR TITLE
Add a `DB` typealias to make composition easier

### DIFF
--- a/Settings.hs
+++ b/Settings.hs
@@ -19,6 +19,13 @@ import Yesod.Default.Config2       (applyEnvValue, configSettingsYml)
 import Yesod.Default.Util          (WidgetFileSettings, widgetFileNoReload,
                                     widgetFileReload)
 
+-- | Actions which only require access to the database connection can be given
+--   type @DB a@ (as opposed to @YesodDB App a@). This allows them to also be
+--   called in tests.
+--   Stolen from https://github.com/thoughtbot/carnival
+type DB a = forall (m :: * -> *).
+    (MonadIO m, Functor m) => ReaderT SqlBackend m a
+
 -- | Runtime settings to configure this application. These settings can be
 -- loaded from various sources: defaults, environment variables, config files,
 -- theoretically even a database.

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -47,6 +47,8 @@ library
                 TupleSections
                 RecordWildCards
 
+                RankNTypes
+
     build-depends: base                          >= 4          && < 5
                  , yesod                         >= 1.4.1      && < 1.5
                  , yesod-core                    >= 1.4.17     && < 1.5


### PR DESCRIPTION
This makes it easier to move `runDB` to a separate function from e.g.  `selectList`, making it easier to reuse and compose database-related functions.
