### PR TITLE
Add task to update Twitter with today's monikers

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -35,7 +35,7 @@ import System.Log.FastLogger                (defaultBufSize, newStdoutLoggerSet,
 -- Don't forget to add new modules to your cabal file!
 import Handler.Common
 import Handler.Moniker
-import Handler.TodaysMonikersTask (printTodaysMonikers)
+import Handler.TodaysMonikersTask (updateTodaysMonikers)
 
 -- This line actually creates our YesodDispatch instance. It is the second half
 -- of the call to mkYesodData which occurs in Foundation.hs. Please see the
@@ -167,7 +167,7 @@ shutdownApp :: App -> IO ()
 shutdownApp _ = return ()
 
 todaysMonikersTaskMain :: IO ()
-todaysMonikersTaskMain = handler printTodaysMonikers
+todaysMonikersTaskMain = handler updateTodaysMonikers
 
 ---------------------------------------------
 -- Functions for use in development with GHCi

--- a/Handler/TodaysMonikersTask.hs
+++ b/Handler/TodaysMonikersTask.hs
@@ -1,9 +1,11 @@
 module Handler.TodaysMonikersTask where
 
 import Import
-import Model.Moniker
+import Model.Moniker (monikersFromToday)
+import TwitterClient (updateTwitterName)
 
-printTodaysMonikers :: Handler ()
-printTodaysMonikers = do
-    todaysMonikers <- runDB monikersFromToday
-    print $ map entityVal todaysMonikers
+updateTodaysMonikers :: Handler ()
+updateTodaysMonikers = do
+    monikers <- runDB monikersFromToday
+    let monikerNames = map (monikerName . entityVal) monikers
+    liftIO $ mapM_ updateTwitterName monikerNames

--- a/app/TwitterClient.hs
+++ b/app/TwitterClient.hs
@@ -1,0 +1,29 @@
+module TwitterClient (
+    updateTwitterName
+    ) where
+
+import Import
+import Configuration.Dotenv (loadFile)
+import Control.Lens ((.~), (&), (?~))
+import Network.Wreq as Wreq (auth, defaults, postWith, param, oauth1Auth, Auth)
+import System.Environment (getEnv)
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.Text as T
+
+-- https://dev.twitter.com/rest/reference/post/account/update_profile
+updateTwitterName :: T.Text -> IO ()
+updateTwitterName newName = do
+    let url = "https://api.twitter.com/1.1/account/update_profile.json"
+    twitterAuth <- twitterAuthentication
+    let opts = defaults & param "name" .~ [newName] & auth ?~ twitterAuth
+    -- Null because we don't send anything in the post body
+    void $ postWith opts url Null
+
+twitterAuthentication :: IO Wreq.Auth
+twitterAuthentication = do
+    loadFile False ".env"
+    consumerKey <- BSC.pack <$> getEnv "TWITTER_CONSUMER_KEY"
+    consumerSecret <- BSC.pack <$> getEnv "TWITTER_CONSUMER_SECRET"
+    accessKey <- BSC.pack <$> getEnv "TWITTER_ACCESS_KEY"
+    accessSecret <- BSC.pack <$> getEnv "TWITTER_ACCESS_SECRET"
+    return $ oauth1Auth consumerKey consumerSecret accessKey accessSecret

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -24,6 +24,7 @@ library
                      Handler.Common
                      Handler.Moniker
                      Handler.TodaysMonikersTask
+                     TwitterClient
 
     if flag(dev) || flag(library-only)
         cpp-options:   -DDEVELOPMENT
@@ -88,6 +89,13 @@ library
                  , case-insensitive
                  , wai
                  , blaze-markup
+
+                 , base64-bytestring
+                 , dotenv
+                 , lens
+                 , lens-aeson
+                 , network-uri
+                 , wreq-sb
 
 executable         croniker
     if flag(library-only)

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,23 @@ packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- aeson-0.10.0.0
+- aeson-compat-0.3.0.0
+- base-compat-0.9.0
+- base-orphans-0.5.0
+- dotenv-0.1.0.9
+- email-validate-2.2.0
+- mono-traversable-0.10.1
+- optparse-applicative-0.12.1.0
+- persistent-2.2.4
+- persistent-postgresql-2.2.2
+- persistent-template-2.1.5
+- postgresql-simple-0.5.1.2
+- semigroupoids-5.0.1
+- wai-extra-3.0.14
+- wreq-sb-0.4.0.0
+- yaml-0.8.15.2
 
 # Override default flag values for local packages and extra-deps
 flags:


### PR DESCRIPTION
Running `stack exec todays-moniker` will:
- Find monikers whose date is today (which, since there's a unique index on the moniker date column , will only ever be 1 moniker right now)
- Call `updateTwitterName` on those moniker(s)
