### PR TITLE
Users can authenticate with Twitter

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -30,6 +30,9 @@ import Network.Wai.Middleware.RequestLogger (Destination (Logger),
                                              mkRequestLogger, outputFormat)
 import System.Log.FastLogger                (defaultBufSize, newStdoutLoggerSet,
                                              toLogStr)
+import Configuration.Dotenv (loadFile)
+import System.Environment (getEnv)
+import qualified Data.ByteString.Char8 as BSC
 
 -- Import all relevant handler modules here.
 -- Don't forget to add new modules to your cabal file!
@@ -55,6 +58,10 @@ makeFoundation appSettings = do
     appStatic <-
         (if appMutableStatic appSettings then staticDevel else static)
         (appStaticDir appSettings)
+    loadFile False ".env"
+    twitterConsumerKey <- BSC.pack <$> getEnv "TWITTER_CONSUMER_KEY"
+    twitterConsumerSecret <- BSC.pack <$> getEnv "TWITTER_CONSUMER_SECRET"
+    let sessionKey = "twitterUserId"
 
     -- We need a log function to create a connection pool. We need a connection
     -- pool to create our foundation. And we need our foundation to get a

--- a/Handler/Moniker.hs
+++ b/Handler/Moniker.hs
@@ -13,6 +13,8 @@ instance ToMarkup Day where
 
 getMonikerR :: Handler Html
 getMonikerR = do
+    (Entity _ user) <- requireAuth
+    liftIO $ print user
     today <- liftIO M.today
     tomorrow <- liftIO M.tomorrow
     (formWidget, formEnctype) <- generateFormPost (bootstrapMonikerForm tomorrow)
@@ -22,6 +24,7 @@ getMonikerR = do
 
 postMonikerR :: Handler Html
 postMonikerR = do
+    (Entity _ user) <- requireAuth
     tomorrow <- liftIO M.tomorrow
     ((result, formWidget), formEnctype) <- runFormPost (bootstrapMonikerForm tomorrow)
     case result of

--- a/Model/User.hs
+++ b/Model/User.hs
@@ -1,0 +1,28 @@
+module Model.User
+    ( authenticateUser
+    , findSessionUser
+    ) where
+
+import Import.NoFoundation
+
+import Data.Maybe (fromJust)
+
+authenticateUser :: AuthId m ~ UserId => Creds m -> DB (AuthenticationResult m)
+authenticateUser Creds{..} = do
+    let twitterUserId = fromJust $ lookup "user_id" credsExtra
+    muser <- getBy $ UniqueUser twitterUserId
+    case muser of
+      Nothing -> Authenticated <$> insert (credsToUser credsExtra)
+      (Just user) -> return $ Authenticated $ entityKey user
+
+credsToUser :: [(Text, Text)] -> User
+credsToUser credsExtra = fromJust $ User
+    <$> (lookup "user_id" credsExtra)
+    <*> (lookup "screen_name" credsExtra)
+    <*> (lookup "oauth_token" credsExtra)
+    <*> (lookup "oauth_token_secret" credsExtra)
+
+findSessionUser :: Maybe Text -> DB (Maybe UserId)
+findSessionUser mTwitterId = do
+    muser <- maybe (return Nothing) (getBy . UniqueUser) mTwitterId
+    return $ maybe Nothing (Just . entityKey) muser

--- a/config/models
+++ b/config/models
@@ -6,15 +6,12 @@
 -- instead of
 -- Name
 User
-    ident Text
-    password Text Maybe
-    UniqueUser ident
-    deriving Typeable
-Email
-    email Text
-    userId UserId Maybe
-    verkey Text Maybe
-    UniqueEmail email
+    twitterUserId Text
+    twitterUsername Text
+    twitterOauthToken Text
+    twitterOauthTokenSecret Text
+    UniqueUser twitterUserId
+    deriving Typeable Show
 Moniker
     name Text
     date Day

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -19,6 +19,7 @@ library
                      Import.NoFoundation
                      Model
                      Model.Moniker
+                     Model.User
                      Settings
                      Settings.StaticFiles
                      Handler.Common
@@ -96,6 +97,7 @@ library
                  , lens-aeson
                  , network-uri
                  , wreq-sb
+                 , yesod-auth-oauth
 
 executable         croniker
     if flag(library-only)

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,6 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- aeson-0.10.0.0
 - aeson-compat-0.3.0.0
 - base-compat-0.9.0
 - base-orphans-0.5.0

--- a/templates/login.hamlet
+++ b/templates/login.hamlet
@@ -1,0 +1,6 @@
+<div .login>
+  <h2>
+    Please sign in
+  <div .login-button>
+    <a .button href=@{AuthR twitterUrl}>
+      Sign in with Twitter

--- a/templates/monikers.hamlet
+++ b/templates/monikers.hamlet
@@ -1,3 +1,5 @@
+<h2>Hello, #{userTwitterUsername user}!
+
 <div>Today is #{today}, at least in UTC
 
 $if null todaysMonikers


### PR DESCRIPTION
This commit handles both sign in and sign up.

The `authenticate` function is a magic callback that gets called after the user authenticates through Twitter. It receives all of the information from Twitter in a Creds object, which has a relevant information (screen name, oauth token, oauth secret, etc) in the `credsExtra` field.

When `authenticate` receives the Twitter credentials, it sets `sessionKey` (which is stored on App) in the session to the Twitter ID. It doesn't use the Twitter name because that might change. Then it runs `authenticateUser`, which finds or creates a user based on the credentials.

When we need to find a user (with `requireAuth`, since the authorization rules guarantee a user is signed in for the MonikerR route), it uses `maybeAuthId`, which searches the session for `sessionKey` and uses it to find a user.
