### PR TITLE
Defining our own maybeAuthId isn't necessary

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -61,7 +61,6 @@ makeFoundation appSettings = do
     loadFile False ".env"
     twitterConsumerKey <- BSC.pack <$> getEnv "TWITTER_CONSUMER_KEY"
     twitterConsumerSecret <- BSC.pack <$> getEnv "TWITTER_CONSUMER_SECRET"
-    let sessionKey = "twitterUserId"
 
     -- We need a log function to create a connection pool. We need a connection
     -- pool to create our foundation. And we need our foundation to get a

--- a/Foundation.hs
+++ b/Foundation.hs
@@ -11,8 +11,7 @@ import qualified Yesod.Core.Unsafe as Unsafe
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Text.Encoding as TE
 
-import Model.User (authenticateUser, findSessionUser)
-import Data.Maybe (fromJust)
+import Model.User (authenticateUser)
 
 -- | The foundation datatype for your application. This can be a good place to
 -- keep settings and values requiring initialization before your application
@@ -26,7 +25,6 @@ data App = App
     , appLogger             :: Logger
     , twitterConsumerKey    :: ByteString
     , twitterConsumerSecret :: ByteString
-    , sessionKey            :: Text
     }
 
 -- This is where we define all of the routes in our application. For a full
@@ -142,13 +140,7 @@ instance YesodAuth App where
 
     -- This is a callback function that gets called with the credentials
     -- obtained by authenticating to Twitter.
-    authenticate creds = do
-        app <- getYesod
-        let twitterId = fromJust $ lookup "user_id" (credsExtra creds)
-        setSession (sessionKey app) twitterId
-        runDB $ authenticateUser creds
-
-    maybeAuthId = getYesod >>= lookupSession . sessionKey >>= runDB . findSessionUser
+    authenticate = runDB . authenticateUser
 
     authPlugins app = [authTwitter (twitterConsumerKey app) (twitterConsumerSecret app)]
 

--- a/Model/User.hs
+++ b/Model/User.hs
@@ -1,6 +1,5 @@
 module Model.User
     ( authenticateUser
-    , findSessionUser
     ) where
 
 import Import.NoFoundation
@@ -21,8 +20,3 @@ credsToUser credsExtra = fromJust $ User
     <*> (lookup "screen_name" credsExtra)
     <*> (lookup "oauth_token" credsExtra)
     <*> (lookup "oauth_token_secret" credsExtra)
-
-findSessionUser :: Maybe Text -> DB (Maybe UserId)
-findSessionUser mTwitterId = do
-    muser <- maybe (return Nothing) (getBy . UniqueUser) mTwitterId
-    return $ entityKey <$> muser


### PR DESCRIPTION
The [minimal complete definition](https://hackage.haskell.org/package/yesod-auth-1.4.12/docs/Yesod-Auth.html#t:YesodAuth) for YesodAuth is:

`loginDest, logoutDest, (authenticate | getAuthId), authPlugins, authHttpManager`

Since that list _doesn't_ include `maybeAuthId`, we can assume that implementing
`authenticate` (and the rest of the functions) defines a sane `maybeAuthId` for
us. And in fact it does!  Everything Just Works! Wow!

We also don't need to do anything with the session since we're not passing any
data between `authenticate` and `maybeAuthId`, so `sessionKey` in Application
can go away as well as a bunch of session-related code.
