### PR TITLE
Associate monikers with the current user

### DIFF
--- a/config/models
+++ b/config/models
@@ -15,5 +15,6 @@ User
 Moniker
     name Text
     date Day
-    UniqueDate date
+    userId UserId
+    UniqueUserDate userId date
     deriving Show


### PR DESCRIPTION
- Add foreign user key on monikers table
- Use `pure` in the form to set the user id on the Moniker without actually
  creating a field for it
