### PR TITLE
Sessions are valid for a week

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -54,11 +54,11 @@ instance Yesod App where
             Nothing -> getApprootText guessApproot app req
             Just root -> root
 
-    -- Store session data on the client in encrypted cookies,
-    -- default session idle timeout is 120 minutes
-    makeSessionBackend _ = Just <$> defaultClientSessionBackend
-        120    -- timeout in minutes
-        "config/client_session_key.aes"
+    -- Store session data on the client in encrypted cookies
+    makeSessionBackend _ = Just <$> defaultClientSessionBackend oneWeek filePath
+        where
+            oneWeek = 60 * 24 * 7
+            filePath = "config/client_session_key.aes"
 
     -- Yesod Middleware allows you to run code before and after each handler function.
     -- The defaultYesodMiddleware adds the response header "Vary: Accept, Accept-Language" and performs authorization checks.


### PR DESCRIPTION
The default is 120 (2 hours), but even with Yesod's auto-reset (every time it
receives a request, it resets the timer) that's annoyingly short:
- People are unlikely to be on this site more than once per two hours
- Thus they will be signed out on each visit
- And they will have to re-OAuth to twitter each time
- Which is annoying
