### PR TITLE
Use each user's individual OAuth tokens

### DIFF
--- a/Handler/TodaysMonikersTask.hs
+++ b/Handler/TodaysMonikersTask.hs
@@ -3,9 +3,21 @@ module Handler.TodaysMonikersTask where
 import Import
 import Model.Moniker (allMonikersFromToday)
 import TwitterClient (updateTwitterName)
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.Text as T
 
 updateTodaysMonikers :: Handler ()
 updateTodaysMonikers = do
-    monikers <- runDB allMonikersFromToday
-    let monikerNames = map (monikerName . entityVal) monikers
-    liftIO $ mapM_ updateTwitterName monikerNames
+    App{..} <- getYesod
+    monikers <- map entityVal <$> runDB allMonikersFromToday
+    mapM_ (updateName twitterConsumerKey twitterConsumerSecret) monikers
+    where
+        updateName :: ByteString -> ByteString -> Moniker -> Handler ()
+        updateName consumerKey consumerSecret (Moniker name _ userId) = do
+            muser <- runDB $ get userId
+            case muser of
+                Nothing -> return ()
+                (Just user) -> do
+                    let accessKey = BSC.pack $ T.unpack $ userTwitterOauthToken user
+                    let accessSecret = BSC.pack $ T.unpack $ userTwitterOauthTokenSecret user
+                    liftIO $ updateTwitterName name consumerKey consumerSecret accessKey accessSecret

--- a/app/TwitterClient.hs
+++ b/app/TwitterClient.hs
@@ -10,18 +10,10 @@ import qualified Data.ByteString.Char8 as BSC
 import qualified Data.Text as T
 
 -- https://dev.twitter.com/rest/reference/post/account/update_profile
-updateTwitterName :: T.Text -> IO ()
-updateTwitterName newName = do
+updateTwitterName :: T.Text -> ByteString -> ByteString -> ByteString -> ByteString ->  IO ()
+updateTwitterName newName consumerKey consumerSecret accessKey accessSecret = do
     let url = "https://api.twitter.com/1.1/account/update_profile.json"
-    twitterAuth <- twitterAuthentication
+    let twitterAuth = oauth1Auth consumerKey consumerSecret accessKey accessSecret
     let opts = defaults & param "name" .~ [newName] & auth ?~ twitterAuth
     -- Null because we don't send anything in the post body
     void $ postWith opts url Null
-
-twitterAuthentication :: IO Wreq.Auth
-twitterAuthentication = do
-    consumerKey <- BSC.pack <$> getEnv "TWITTER_CONSUMER_KEY"
-    consumerSecret <- BSC.pack <$> getEnv "TWITTER_CONSUMER_SECRET"
-    accessKey <- BSC.pack <$> getEnv "TWITTER_ACCESS_KEY"
-    accessSecret <- BSC.pack <$> getEnv "TWITTER_ACCESS_SECRET"
-    return $ oauth1Auth consumerKey consumerSecret accessKey accessSecret


### PR DESCRIPTION
We were reading my (`@gabebw`) access tokens every time, instead of pulling each user's token from the database and using them.
