### PR TITLE
Parse Heroku's `DATABASE_URL` environment variable

### DIFF
--- a/Settings.hs
+++ b/Settings.hs
@@ -61,6 +61,8 @@ data AppSettings = AppSettings
     -- ^ Copyright text to appear in the footer of the page
     , appAnalytics              :: Maybe Text
     -- ^ Google Analytics code
+    , appDatabaseUrl            :: Bool
+    -- ^ Parse database info from DATABASE_URL?
     }
 
 instance FromJSON AppSettings where
@@ -86,6 +88,7 @@ instance FromJSON AppSettings where
 
         appCopyright              <- o .: "copyright"
         appAnalytics              <- o .:? "analytics"
+        appDatabaseUrl            <- o .:? "database-url"     .!= (not defaultDev)
 
         return AppSettings {..}
 

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -95,6 +95,7 @@ library
 
                  , base64-bytestring
                  , dotenv
+                 , heroku-persistent
                  , lens
                  , lens-aeson
                  , network-uri

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,8 @@ extra-deps:
 - base-orphans-0.5.0
 - dotenv-0.1.0.9
 - email-validate-2.2.0
+- heroku-0.1.2.3
+- heroku-persistent-0.1.0
 - mono-traversable-0.10.1
 - optparse-applicative-0.12.1.0
 - persistent-2.2.4


### PR DESCRIPTION
Use heroku-persistent: http://hackage.haskell.org/package/heroku-persistent

It does not use `DATABASE_URL` when running in development mode.
