### PR TITLE
Serialize TZLabel to the database as a field

### DIFF
--- a/Data/TZLabel.hs
+++ b/Data/TZLabel.hs
@@ -1,0 +1,21 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Data.TZLabel where
+
+import ClassyPrelude.Yesod
+import Database.Persist ()
+import Database.Persist.Sql
+import Data.Time.Zones.All (TZLabel, fromTZName, toTZName)
+import Helper.TextConversion
+import qualified Data.Text as T (pack)
+
+-- (De)serialize a TZLabel as a Text field in the database
+instance PersistField TZLabel where
+    toPersistValue tzLabel = PersistText $ b2t $ toTZName tzLabel
+    fromPersistValue (PersistText text) =
+        case fromTZName (t2b text) of
+            (Just tzLabel) -> Right tzLabel
+            Nothing -> Left ("Bad TZ name: " <> text)
+    fromPersistValue bad = Left ("Bad TZ name: " <> (T.pack (show bad)))
+
+instance PersistFieldSql TZLabel where
+    sqlType _ = SqlString

--- a/Helper/TextConversion.hs
+++ b/Helper/TextConversion.hs
@@ -1,0 +1,15 @@
+module Helper.TextConversion
+    ( b2t
+    , t2b)
+    where
+
+import Prelude
+
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.Text as T
+
+b2t :: BSC.ByteString -> T.Text
+b2t = T.pack . BSC.unpack
+
+t2b :: T.Text -> BSC.ByteString
+t2b = BSC.pack . T.unpack

--- a/Model.hs
+++ b/Model.hs
@@ -4,6 +4,8 @@ module Model where
 
 import ClassyPrelude.Yesod
 import Database.Persist.Quasi
+import Data.Time.Zones.All (TZLabel)
+import Data.TZLabel ()
 
 -- You can define all of your database entities in the entities file.
 -- You can find more information on persistent and how to declare entities

--- a/Model/User.hs
+++ b/Model/User.hs
@@ -4,6 +4,8 @@ module Model.User
 
 import Import.NoFoundation
 
+import Data.Time.Zones.All (TZLabel(Etc__UTC))
+
 authenticateUser :: AuthId m ~ UserId => Creds m -> DB (AuthenticationResult m)
 authenticateUser Creds{..} = do
     let mTwitterUserId = (lookup "user_id" credsExtra)
@@ -22,3 +24,7 @@ credsToUser credsExtra = User
     <*> (lookup "screen_name" credsExtra)
     <*> (lookup "oauth_token" credsExtra)
     <*> (lookup "oauth_token_secret" credsExtra)
+    <*> pure defaultTZLabel
+
+defaultTZLabel :: TZLabel
+defaultTZLabel = Etc__UTC

--- a/config/models
+++ b/config/models
@@ -10,6 +10,7 @@ User
     twitterUsername Text
     twitterOauthToken Text
     twitterOauthTokenSecret Text
+    tzLabel TZLabel default='Etc/UTC'
     UniqueUser twitterUserId
     deriving Typeable Show
 Moniker

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -14,8 +14,10 @@ Flag library-only
 library
     hs-source-dirs: ., app
     exposed-modules: Application
+                     Data.TZLabel
                      Foundation
                      Helper.Request
+                     Helper.TextConversion
                      Import
                      Import.NoFoundation
                      Model
@@ -99,6 +101,7 @@ library
                  , lens
                  , lens-aeson
                  , network-uri
+                 , tz
                  , wreq-sb
                  , yesod-auth-oauth
 


### PR DESCRIPTION
This adds instances for `PersistField` and `PersistFieldSql` to `TZLabel`, which tells Persistent how to serialize it to the database.

It's serialized to the database as a string: for example, `Etc__UTC` becomes `"Etc/UTC"`.

All users default to UTC.
