### PR TITLE
Users must choose a timezone before using the app

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -38,6 +38,7 @@ import qualified Data.ByteString.Char8 as BSC
 
 -- Import all relevant handler modules here.
 -- Don't forget to add new modules to your cabal file!
+import Handler.ChooseTimezone
 import Handler.Common
 import Handler.Moniker
 import Handler.Root

--- a/Handler/ChooseTimezone.hs
+++ b/Handler/ChooseTimezone.hs
@@ -1,0 +1,15 @@
+module Handler.ChooseTimezone
+    ( getChooseTimezoneR
+    ) where
+
+import Import
+
+import Handler.UpdateUser (timezoneForm)
+
+getChooseTimezoneR :: Handler Html
+getChooseTimezoneR = do
+    (Entity userId user) <- requireAuth
+    (tzWidget, tzEnc) <- generateFormPost (timezoneForm user)
+    defaultLayout $ do
+        setTitle "Croniker"
+        $(widgetFile "choose_timezone")

--- a/Handler/UpdateUser.hs
+++ b/Handler/UpdateUser.hs
@@ -14,7 +14,7 @@ postUpdateUserR userId = do
     ((result, _), _) <- runFormPost (timezoneForm user)
     case result of
         FormSuccess newUser -> do
-            void $ runDB $ replace userId newUser
+            void $ runDB $ replace userId $ newUser { userChoseTimezone = True }
             setMessage "Time zone updated"
             redirect RootR
         _ -> do
@@ -27,7 +27,8 @@ timezoneForm User{..} = renderDivs $ User
        <*> pure userTwitterUsername
        <*> pure userTwitterOauthToken
        <*> pure userTwitterOauthTokenSecret
-       <*> areq (selectFieldList selectTZs) "Choose your timezone" (Just userTzLabel)
+       <*> areq (selectFieldList selectTZs) "" (Just userTzLabel)
+       <*> pure False
     where
         selectTZs :: [(Text, TZLabel)]
         selectTZs = map (\tzlabel -> (b2t $ toTZName tzlabel, tzlabel)) [Africa__Abidjan .. Root__WET]

--- a/Model/User.hs
+++ b/Model/User.hs
@@ -28,6 +28,7 @@ credsToUser credsExtra = User
     <*> (lookup "oauth_token" credsExtra)
     <*> (lookup "oauth_token_secret" credsExtra)
     <*> pure defaultTZLabel
+    <*> pure False
 
 defaultTZLabel :: TZLabel
 defaultTZLabel = Etc__UTC

--- a/config/models
+++ b/config/models
@@ -11,6 +11,7 @@ User
     twitterOauthToken Text
     twitterOauthTokenSecret Text
     tzLabel TZLabel default='Etc/UTC'
+    choseTimezone Bool default=False
     UniqueUser twitterUserId
     deriving Typeable Show
 Moniker

--- a/config/routes
+++ b/config/routes
@@ -5,6 +5,7 @@
 /robots.txt RobotsR GET
 
 / RootR GET
+/timezone ChooseTimezoneR GET
 /monikers MonikerR GET POST
 /monikers/#MonikerId/delete DeleteMonikerR POST
 /user/#UserId/update UpdateUserR POST

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -16,6 +16,7 @@ library
     exposed-modules: Application
                      Data.TZLabel
                      Foundation
+                     Handler.ChooseTimezone
                      Handler.Common
                      Handler.DeleteMoniker
                      Handler.Moniker

--- a/templates/choose_timezone.hamlet
+++ b/templates/choose_timezone.hamlet
@@ -1,0 +1,10 @@
+<div>
+    <h2>Hi!
+    <p>
+        Croniker will set your name at 5am on the day you choose. In order to
+        know when 5am is for you, please choose your timezone.
+    <div.form>
+        <form method=post action=@{UpdateUserR userId} enctype=#{tzEnc}>
+            ^{tzWidget}
+            <button type="submit">
+                Submit

--- a/templates/monikers.hamlet
+++ b/templates/monikers.hamlet
@@ -1,14 +1,8 @@
 <div.page-monikers>
     <div.form>
-        <form method=post action=@{UpdateUserR userId}#form enctype=#{tzEnc}>
-            ^{tzWidget}
-            <p>(It's #{timeZoneName $ timeZoneForUTCTime (tzByLabel $ userTzLabel user) now} where you are.)
-            <button type="submit">
-                Submit
-
         <form method=post action=@{MonikerR}#form enctype=#{monikerEnc}>
             ^{monikerWidget}
-            <p>(It's #{formatTime defaultTimeLocale "%B %e" today} where you are.)
+            <p>(It's #{formatTime defaultTimeLocale "%B %e %H:%M:%S" today} where you are.)
             <button type="submit">
                 Submit
 


### PR DESCRIPTION
They're really choosing a time zone label like "America/Los_Angeles", not a timezone like "PST", but we can deal with that later.

Before creating monikers, logged-in users will always be redirected to a page to choose a timezone, which will set their `chose_timezone` column to `True` (it's default `False`)