### PR TITLE
Move today/tomorrow into its own module

### DIFF
--- a/Data/RelativeTimes.hs
+++ b/Data/RelativeTimes.hs
@@ -1,0 +1,20 @@
+module Data.RelativeTimes
+    ( today
+    , tomorrow
+    ) where
+
+import ClassyPrelude.Yesod
+
+import Data.Time
+
+today :: (MonadIO m) => m Day
+today = liftIO getCurrentTime >>= dayM
+
+tomorrow :: (MonadIO m) => m Day
+tomorrow = liftIO getCurrentTime >>= dayM . addUTCTime oneDay
+
+dayM :: (MonadIO m) => UTCTime -> m Day
+dayM = return . utctDay
+
+oneDay :: NominalDiffTime
+oneDay = 60 * 60 * 24

--- a/Handler/Moniker.hs
+++ b/Handler/Moniker.hs
@@ -12,6 +12,7 @@ import Text.Blaze (ToMarkup, toMarkup)
 import Helper.Request (fromMaybe404)
 import qualified Model.Moniker as M
 import qualified Model.User as U
+import qualified Data.RelativeTimes as RT
 
 instance ToMarkup Day where
   toMarkup = toMarkup . show
@@ -25,7 +26,7 @@ prerequisites = do
 getMonikerR :: Handler Html
 getMonikerR = do
     euser@(Entity userId _) <- prerequisites
-    tomorrow <- liftIO M.tomorrow
+    tomorrow <- RT.tomorrow
     monikerFormPost <- generateFormPost $ monikerForm tomorrow userId
     monikersTemplate euser monikerFormPost
 
@@ -35,7 +36,7 @@ requireSetTimezone user = when (not $ userChoseTimezone user) (redirect ChooseTi
 postMonikerR :: Handler Html
 postMonikerR = do
     euser@(Entity userId _) <- prerequisites
-    tomorrow <- liftIO M.tomorrow
+    tomorrow <- RT.tomorrow
     ((result, formWidget), formEnctype) <- runFormPost $ monikerForm tomorrow userId
     case result of
         FormSuccess moniker -> do

--- a/Model/Moniker.hs
+++ b/Model/Moniker.hs
@@ -3,36 +3,26 @@ module Model.Moniker
     , monikersFromTodayFor
     , allMonikersFromToday
     , findMonikerFor
-    , today
-    , tomorrow
     ) where
 
 import Import
 
-import Data.Time.Clock (addUTCTime)
+import Data.RelativeTimes
 
 findMonikerFor :: UserId -> MonikerId -> DB (Maybe (Entity Moniker))
 findMonikerFor userId monikerId = selectFirst [MonikerUserId ==. userId, MonikerId ==. monikerId] []
 
 futureMonikersFor :: UserId -> DB [Entity Moniker]
 futureMonikersFor userId = do
-    day <- liftIO today
+    day <- today
     selectList [MonikerUserId ==. userId, MonikerDate >=. day] [Asc MonikerDate]
 
 monikersFromTodayFor :: UserId -> DB [Entity Moniker]
 monikersFromTodayFor userId = do
-    day <- liftIO today
+    day <- today
     selectList [MonikerUserId ==. userId, MonikerDate ==. day] [Asc MonikerDate]
 
 allMonikersFromToday :: DB [Entity Moniker]
 allMonikersFromToday = do
-    day <- liftIO today
+    day <- today
     selectList [MonikerDate ==. day] [Asc MonikerDate]
-
-today :: IO Day
-today = getCurrentTime >>= return . utctDay
-
-tomorrow :: IO Day
-tomorrow = do
-    let oneDay = fromInteger $ 60 * 60 * 24
-    getCurrentTime >>= return . utctDay . (addUTCTime oneDay)

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -14,6 +14,7 @@ Flag library-only
 library
     hs-source-dirs: ., app
     exposed-modules: Application
+                     Data.RelativeTimes
                      Data.TZLabel
                      Foundation
                      Handler.ChooseTimezone


### PR DESCRIPTION
The functions are not Moniker-specific, so move them into their own module.

Improvement: `liftIO tomorrow` is no longer required. The functions from `Data.RelativeTimes` now lift themselves.