### PR TITLE
Only update a user's moniker if it's set for today *in their time zone*

### DIFF
--- a/Data/RelativeTimes.hs
+++ b/Data/RelativeTimes.hs
@@ -1,6 +1,7 @@
 module Data.RelativeTimes
     ( today
     , tomorrow
+    , yesterday
     ) where
 
 import ClassyPrelude.Yesod
@@ -12,6 +13,9 @@ today = liftIO getCurrentTime >>= dayM
 
 tomorrow :: (MonadIO m) => m Day
 tomorrow = liftIO getCurrentTime >>= dayM . addUTCTime oneDay
+
+yesterday :: (MonadIO m) => m Day
+yesterday = liftIO getCurrentTime >>= dayM . addUTCTime (-1 * oneDay)
 
 dayM :: (MonadIO m) => UTCTime -> m Day
 dayM = return . utctDay

--- a/Handler/TodaysMonikersTask.hs
+++ b/Handler/TodaysMonikersTask.hs
@@ -6,21 +6,44 @@ import Import
 
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.Text as T
-import Model.Moniker (allMonikersFromToday)
+import Data.Time.Zones (timeZoneForUTCTime)
+import Data.Time.Zones.All (tzByLabel)
+import Data.Time.LocalTime (utcToLocalTime, LocalTime(..))
+import Model.Moniker (allMonikersForUpdate)
 import TwitterClient (updateTwitterName)
 
 updateTodaysMonikers :: Handler ()
 updateTodaysMonikers = do
     App{..} <- getYesod
-    monikers <- map entityVal <$> runDB allMonikersFromToday
-    mapM_ (updateName twitterConsumerKey twitterConsumerSecret) monikers
+    now <- liftIO $ getCurrentTime
+    monikers <- map entityVal <$> runDB allMonikersForUpdate
+    filteredMonikers <- filterM (isTime now) monikers
+    mapM_ (updateName twitterConsumerKey twitterConsumerSecret) filteredMonikers
+
+updateName :: ByteString -> ByteString -> Moniker -> Handler ()
+updateName consumerKey consumerSecret (Moniker name _ userId) = do
+    muser <- runDB $ get userId
+    case muser of
+        Nothing -> return ()
+        (Just user) -> do
+            let accessKey = BSC.pack $ T.unpack $ userTwitterOauthToken user
+            let accessSecret = BSC.pack $ T.unpack $ userTwitterOauthTokenSecret user
+            liftIO $ updateTwitterName name consumerKey consumerSecret accessKey accessSecret
+
+isTime :: UTCTime -> Moniker -> Handler Bool
+isTime utcNow (Moniker _ monikerDay userId) = do
+    muser <- runDB $ get userId
+    return $ case muser of
+      Nothing -> False
+      (Just user) -> (userDay utcNow user) == monikerDay
+
+-- Convert the current time in UTC into the user's current day.
+-- For example, if it's February 22nd in UTC, it may be February 21 in PST.
+-- This task runs ~every hour, so if someone sets their moniker for today at 8pm,
+-- it'll get set at (roughly) 9pm that day.
+-- If they set it for tomorrow, it'll get set at (roughly) 12am.
+userDay :: UTCTime -> User -> Day
+userDay utcNow user = localDay $ utcToLocalTime timezone utcNow
     where
-        updateName :: ByteString -> ByteString -> Moniker -> Handler ()
-        updateName consumerKey consumerSecret (Moniker name _ userId) = do
-            muser <- runDB $ get userId
-            case muser of
-                Nothing -> return ()
-                (Just user) -> do
-                    let accessKey = BSC.pack $ T.unpack $ userTwitterOauthToken user
-                    let accessSecret = BSC.pack $ T.unpack $ userTwitterOauthTokenSecret user
-                    liftIO $ updateTwitterName name consumerKey consumerSecret accessKey accessSecret
+        timezone = timeZoneForUTCTime tz utcNow
+        tz = tzByLabel $ userTzLabel user

--- a/Model/Moniker.hs
+++ b/Model/Moniker.hs
@@ -1,7 +1,7 @@
 module Model.Moniker
     ( futureMonikersFor
     , monikersFromTodayFor
-    , allMonikersFromToday
+    , allMonikersForUpdate
     , findMonikerFor
     ) where
 
@@ -22,7 +22,10 @@ monikersFromTodayFor userId = do
     day <- today
     selectList [MonikerUserId ==. userId, MonikerDate ==. day] [Asc MonikerDate]
 
-allMonikersFromToday :: DB [Entity Moniker]
-allMonikersFromToday = do
-    day <- today
-    selectList [MonikerDate ==. day] [Asc MonikerDate]
+-- Due to time zones, we need to find monikers from yesterday/today/tomorrow (in
+-- UTC) because "yesterday"/"tomorrow" in UTC may be "today" in a user's time
+-- zone.
+allMonikersForUpdate :: DB [Entity Moniker]
+allMonikersForUpdate = do
+    days <- sequence [yesterday, today, tomorrow]
+    selectList [MonikerDate <-. days] [Asc MonikerDate]


### PR DESCRIPTION
The moniker's day is stored without a time zone, as a pure date like 2016-2-21.

We interpret it as being in the owning user's timezone.

Here is the process for determining if a moniker should be sent to Twitter:

* Take the current UTC time and, for each user, convert it to that user's
  timezone.
* Using that time, find out what "today" is for that user.
* If "today" for the user is the same as the moniker's day, then the moniker should be updated.

One wrinkle is that, since Postgres doesn't know anything about timezones, we find monikers for UTC yesterday/UTC today/UTC tomorrow since "UTC tomorrow" may be "the user's today". We get some extra monikers that won't be updated this way, but it's easier to filter in Haskell than in Haskell _and_ Postgres.