### PR TITLE
Display the date dropdown in the user's timezone

### DIFF
--- a/Handler/Moniker.hs
+++ b/Handler/Moniker.hs
@@ -25,8 +25,8 @@ prerequisites = do
 
 getMonikerR :: Handler Html
 getMonikerR = do
-    euser@(Entity userId _) <- prerequisites
-    tomorrow <- CT.tomorrow
+    euser@(Entity userId user) <- prerequisites
+    tomorrow <- CT.localTomorrow user
     monikerFormPost <- generateFormPost $ monikerForm tomorrow userId
     monikersTemplate euser monikerFormPost
 
@@ -35,8 +35,8 @@ requireSetTimezone user = when (not $ userChoseTimezone user) (redirect ChooseTi
 
 postMonikerR :: Handler Html
 postMonikerR = do
-    euser@(Entity userId _) <- prerequisites
-    tomorrow <- CT.tomorrow
+    euser@(Entity userId user) <- prerequisites
+    tomorrow <- CT.localTomorrow user
     ((result, formWidget), formEnctype) <- runFormPost $ monikerForm tomorrow userId
     case result of
         FormSuccess moniker -> do
@@ -50,8 +50,7 @@ postMonikerR = do
 monikersTemplate :: (ToWidget App w) => Entity User -> (w, Enctype) -> Handler Html
 monikersTemplate (Entity userId user) (monikerWidget, monikerEnc) = do
     csrfToken <- fromJust . reqToken <$> getRequest
-    now <- liftIO getCurrentTime
-    let today = CT.localTime now user
+    today <- CT.localToday user
     allMonikers <- runDB $ M.futureMonikersFor userId
     defaultLayout $ do
         setTitle "Croniker"

--- a/Handler/TodaysMonikersTask.hs
+++ b/Handler/TodaysMonikersTask.hs
@@ -8,17 +8,14 @@ import Import
 
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.Text as T
-import Data.Time.Zones (timeZoneForUTCTime)
-import Data.Time.Zones.All (tzByLabel)
-import Data.Time.LocalTime (utcToLocalTime, LocalTime(..))
 import Model.Moniker (allMonikersForUpdate)
+import qualified Croniker.Time as CT
 import TwitterClient (updateTwitterName)
 
 updateTodaysMonikers :: Handler ()
 updateTodaysMonikers = do
-    now <- liftIO getCurrentTime
     monikers <- map entityVal <$> runDB allMonikersForUpdate
-    filteredMonikers <- filterM (isTime now) monikers
+    filteredMonikers <- filterM isTime monikers
     mapM_ updateName filteredMonikers
 
 updateName :: Moniker -> Handler ()
@@ -32,20 +29,9 @@ updateName (Moniker name _ userId) = do
             let accessSecret = BSC.pack $ T.unpack $ userTwitterOauthTokenSecret user
             liftIO $ updateTwitterName name twitterConsumerKey twitterConsumerSecret accessKey accessSecret
 
-isTime :: UTCTime -> Moniker -> Handler Bool
-isTime utcNow (Moniker _ monikerDay userId) = do
+isTime :: Moniker -> Handler Bool
+isTime (Moniker _ monikerDay userId) = do
     muser <- runDB $ get userId
-    return $ case muser of
-      Nothing -> False
-      (Just user) -> userDay utcNow user == monikerDay
-
--- Convert the current time in UTC into the user's current day.
--- For example, if it's February 22nd in UTC, it may be February 21 in PST.
--- This task runs ~every hour, so if someone sets their moniker for today at 8pm,
--- it'll get set at (roughly) 9pm that day.
--- If they set it for tomorrow, it'll get set at (roughly) 12am.
-userDay :: UTCTime -> User -> Day
-userDay utcNow user = localDay $ utcToLocalTime timezone utcNow
-    where
-        timezone = timeZoneForUTCTime tz utcNow
-        tz = tzByLabel $ userTzLabel user
+    case muser of
+      Nothing -> return False
+      (Just user) -> (monikerDay ==) <$> CT.localToday user

--- a/src/Croniker/Time.hs
+++ b/src/Croniker/Time.hs
@@ -2,11 +2,12 @@ module Croniker.Time
     ( today
     , tomorrow
     , yesterday
-    , localTime
+    , localToday
+    , localTomorrow
     ) where
 
 import ClassyPrelude.Yesod
-import Model
+import Model (User(..))
 import Data.Time
 import Data.Time.Zones (timeZoneForUTCTime)
 import Data.Time.Zones.All (tzByLabel)
@@ -20,10 +21,22 @@ tomorrow = todayPlus 1
 yesterday :: (MonadIO m) => m Day
 yesterday = todayPlus (-1)
 
-localTime :: UTCTime -> User -> LocalTime
-localTime utcNow user = utcToLocalTime timezone utcNow
+-- Convert the current time in UTC into the user's current day.
+-- For example, if it's February 22nd in UTC, it may be February 21 in PST.
+localToday :: (MonadIO m) => User -> m Day
+localToday user = localDay <$> localTime id user
+
+localTomorrow :: (MonadIO m) => User -> m Day
+localTomorrow user = localDay <$> localTime (addUTCTime oneDay) user
+
+-- Apply a function to the current time in UTC and return the transformed
+-- UTCTime as a LocalTime in the given user's timezone.
+localTime :: (MonadIO m) => (UTCTime -> UTCTime) -> User -> m LocalTime
+localTime f user = do
+    now <- f <$> liftIO getCurrentTime
+    return $ utcToLocalTime (timezone now) now
     where
-        timezone = timeZoneForUTCTime tz utcNow
+        timezone = timeZoneForUTCTime tz
         tz = tzByLabel $ userTzLabel user
 
 todayPlus :: (MonadIO m) => NominalDiffTime -> m Day
@@ -32,5 +45,5 @@ todayPlus diff = liftIO getCurrentTime >>= dayM . addUTCTime (oneDay * diff)
         dayM :: (MonadIO m) => UTCTime -> m Day
         dayM = return . utctDay
 
-        oneDay :: NominalDiffTime
-        oneDay = 60 * 60 * 24
+oneDay :: NominalDiffTime
+oneDay = 60 * 60 * 24


### PR DESCRIPTION
We were displaying the dropdown in UTC, so if it was the 22nd for the user and the 23rd in UTC, the dropdown would default to the 23rd. The backend logic that ensured future dates also used UTC, so if it was already "tomorrow" in UTC, users couldn't enter a name.

Now the code is aware of the user's timezone and uses it everywhere.

Refactoring:

* The `Handler.TodaysMonikersTask.userDay` method was folded into `Croniker.Time.localToday`.