### PR TITLE
Auto-select the user's timezone

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -68,6 +68,7 @@ makeFoundation appSettings = do
 
     twitterConsumerKey <- BSC.pack <$> getEnv "TWITTER_CONSUMER_KEY"
     twitterConsumerSecret <- BSC.pack <$> getEnv "TWITTER_CONSUMER_SECRET"
+    googleApiKey <- getEnv "GOOGLE_API_KEY"
 
     dbconf <- if appDatabaseUrl appSettings
         then postgresConf $ pgPoolSize $ appDatabaseConf appSettings

--- a/Foundation.hs
+++ b/Foundation.hs
@@ -25,6 +25,7 @@ data App = App
     , appLogger             :: Logger
     , twitterConsumerKey    :: ByteString
     , twitterConsumerSecret :: ByteString
+    , googleApiKey          :: String
     }
 
 -- This is where we define all of the routes in our application. For a full

--- a/Handler/ChooseTimezone.hs
+++ b/Handler/ChooseTimezone.hs
@@ -12,4 +12,5 @@ getChooseTimezoneR = do
     (tzWidget, tzEnc) <- generateFormPost (timezoneForm user)
     defaultLayout $ do
         setTitle "Croniker"
+        addScript $ StaticR javascript_selectTimezone_js
         $(widgetFile "choose_timezone")

--- a/Handler/UpdateUser.hs
+++ b/Handler/UpdateUser.hs
@@ -15,7 +15,6 @@ postUpdateUserR userId = do
     case result of
         FormSuccess newUser -> do
             void $ runDB $ replace userId $ newUser { userChoseTimezone = True }
-            setMessage "Time zone updated"
             redirect RootR
         _ -> do
             setMessage "Oops, something went wrong"
@@ -27,7 +26,7 @@ timezoneForm User{..} = renderDivs $ User
        <*> pure userTwitterUsername
        <*> pure userTwitterOauthToken
        <*> pure userTwitterOauthTokenSecret
-       <*> areq (selectFieldList selectTZs) "" (Just userTzLabel)
+       <*> areq (selectFieldList selectTZs) "" Nothing
        <*> pure False
     where
         selectTZs :: [(Text, TZLabel)]

--- a/static/javascript/selectTimezone.js
+++ b/static/javascript/selectTimezone.js
@@ -1,0 +1,41 @@
+window.Croniker = {};
+
+Croniker.geolocate = function(success) {
+  var geolocationJSON = JSON.stringify({ considerIp: true });
+  var geolocationURL = "https://www.googleapis.com/geolocation/v1/geolocate?key=" + window.GOOGLE_API_KEY;
+
+  $.ajax({
+    contentType: "application/json; charset=utf-8",
+    data: geolocationJSON,
+    success: success,
+    method: "POST",
+    url: geolocationURL,
+  });
+};
+
+Croniker.findTimezone = function(data, success) {
+  var lat = data.location.lat;
+  var lng = data.location.lng;
+  var epoch = Date.now() / 10;
+  var timezoneURL = "https://maps.googleapis.com/maps/api/timezone/json?location="+lat+","+lng+"&timestamp="+epoch+"&key="+window.GOOGLE_API_KEY;
+
+  $.get(timezoneURL, success);
+};
+
+Croniker.selectTimezone = function(){
+  var timeZoneSuccess = function(timezoneData) {
+    $(function(){
+      var $select = $("select");
+      var $spinning = $("#spinning");
+      $select.find("option[selected]").prop("selected", "");
+      $select.find("option:contains('"+timezoneData.timeZoneId+"')").prop("selected", "selected");
+      $spinning.text("(It's probably already selected.)");
+    })
+  };
+
+  Croniker.geolocate(function(geolocationData){
+    Croniker.findTimezone(geolocationData, timeZoneSuccess);
+  });
+};
+
+Croniker.selectTimezone();

--- a/templates/choose_timezone.hamlet
+++ b/templates/choose_timezone.hamlet
@@ -1,9 +1,10 @@
 <div>
-    <h2>Hi!
+    <h2>Welcome!
     <p>
-        Croniker will set your name at 5am on the day you choose. In order to
-        know when 5am is for you, please choose your timezone.
+        Croniker will set your name at 1 AM on the day you choose. In order to
+        know when 1 AM is for you, please choose your timezone.
     <div.form>
+        <p#spinning>Trying to find your timezone, please wait...
         <form method=post action=@{UpdateUserR userId} enctype=#{tzEnc}>
             ^{tzWidget}
             <button type="submit">

--- a/templates/default-layout-wrapper.hamlet
+++ b/templates/default-layout-wrapper.hamlet
@@ -15,6 +15,7 @@ $doctype 5
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.0.3/js.cookie.min.js">
 
     <script>
+      window.GOOGLE_API_KEY = "#{googleApiKey master}";
       /* The `defaultCsrfMiddleware` Middleware added in Foundation.hs adds a CSRF token the request cookies. */
       /* AJAX requests should add that token to a header to be validated by the server. */
       /* See the CSRF documentation in the Yesod.Core.Handler module of the yesod-core package for details. */


### PR DESCRIPTION
Croniker uses Google's Geolocation API to find out where the user is, then sends the lat/lng from that to Google's Timezone API to find out what timezone the user is in.