### PR TITLE
Track if profiles have been successfully sent

### DIFF
--- a/Handler/Profile.hs
+++ b/Handler/Profile.hs
@@ -104,7 +104,7 @@ profileForm tomorrow userId extra = do
         ^{display profilePictureView}
         ^{display dayView}
     |]
-    let profile = Profile <$> nameRes <*> dayRes <*> pure userId <*> pure Nothing
+    let profile = Profile <$> nameRes <*> dayRes <*> pure userId <*> pure Nothing <*> pure False
     return (profile, widget)
 
     where

--- a/Model/Profile.hs
+++ b/Model/Profile.hs
@@ -28,4 +28,4 @@ profilesFromTodayFor userId = do
 allProfilesForUpdate :: DB [Entity Profile]
 allProfilesForUpdate = do
     days <- sequence [yesterday, today, tomorrow]
-    selectList [ProfileDate <-. days] [Asc ProfileDate]
+    selectList [ProfileDate <-. days, ProfileSent ==. False] [Asc ProfileDate]

--- a/config/models
+++ b/config/models
@@ -19,5 +19,6 @@ Profile
     date Day
     userId UserId
     picture Text Maybe
+    sent Bool default=False
     UniqueUserDate userId date
     deriving Show

--- a/templates/profiles.hamlet
+++ b/templates/profiles.hamlet
@@ -11,13 +11,15 @@
         $else
             <ul>
                 <div.banner>All changes will happen at 1am on the scheduled day.
-                $forall (Entity profileId (Profile name date _ picture)) <- allProfiles
+                $forall (Entity profileId (Profile name date _ picture sent)) <- allProfiles
                     <li.profile>
                         $maybe b64data <- picture
                             <div.profile-picture>
                                 <img src="data:;base64,#{b64data}">
                         <strong>#{name}
                         <div>#{prettyTime date}
+                        $if sent
+                            <div>Successfully sent to Twitter
                         <form method=post action=@{DeleteProfileR profileId}>
                             <input type="hidden" name="_token" value="#{csrfToken}">
                             <button type="submit" value="">


### PR DESCRIPTION
The cron task on Heroku runs hourly so that it will send profiles as close to midnight as possible in each user's timezone.

However, this means that Croniker will re-send today's profile changes every hour, because it doesn't track if a profile was successfully sent or not.

Now we:

* Track if profiles are successfully sent (`postWith` will throw an error if it fails, and we won't get to update `sent = true`)
* Only update profiles that have not yet been sent