### PR TITLE
Handle errors when updating a profile

### DIFF
--- a/Helper/HttpExceptionHandler.hs
+++ b/Helper/HttpExceptionHandler.hs
@@ -1,0 +1,23 @@
+module Helper.HttpExceptionHandler
+    ( handleHttpException
+    ) where
+
+import Import
+
+import Network.HTTP.Client ()
+
+handleHttpException :: (Either HttpException ()) -> Handler ()
+handleHttpException (Left e) = printHttpException e
+handleHttpException _ = return ()
+
+printHttpException :: MonadIO m => HttpException -> m ()
+printHttpException (StatusCodeException status headers _) = putStrLn $
+    "!!! Error! Status code "
+    <> code
+    <> " "
+    <> errors
+    where
+        errors = tshow $ lookup "X-Response-Body-Start" headers
+        code = tshow $ statusCode status
+
+printHttpException e = putStrLn $ "!!! Error! (not status code) " <> tshow e

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -24,6 +24,7 @@ library
                      Handler.Root
                      Handler.TodaysProfilesTask
                      Handler.UpdateUser
+                     Helper.HttpExceptionHandler
                      Helper.Request
                      Helper.TextConversion
                      Import
@@ -109,6 +110,8 @@ library
                  , wreq-sb
                  , yesod-auth-oauth
                  , conduit-extra
+                 , http-client
+                 , lifted-base
 
 executable         croniker
     if flag(library-only)


### PR DESCRIPTION
The functions that are most likely to fail (through no fault of their own) are the functions from `TwitterClient`. They fail because of bad or expired OAuth tokens. Hopefully 28527d5dd4d681aa5e43a67ee59dc61b96cbce71 fixes that for 99% of cases, but we might still store invalid OAuth tokens if a user revokes access.

**Q**: What happens if there are invalid OAuth tokens in the database?

**A**: Updating that user's Twitter profile fails. More specifically, it fails by throwing an error, which stops all updating of all twitter profiles. So if Croniker is set to update users A, B, and C, and B fails, then it will never get to user C.

Ideally, B will fail, we'll log an error, and C will continue as usual. Each update should catch errors and then move on. After this commit, that is in fact how Croniker behaves.

It's worth noting that the error handling is around the entire `updateProfile` function (which calls `TwitterClient` functions), rather than around each `TwitterClient` function. This is because `updateProfile` runs the `TwitterClient` functions, then _marks the profile as sent in the database_. If we handle errors at the lower `TwitterClient` level, we'll glide right over Twitter authentication errors and...mark the profile as sent. Instead, we need to wrap the error handling around a larger, higher-level chunk of code: the entire `updateProfile` function.