### PR TITLE
Introduce a Reader monad and `OauthCredentials`

### DIFF
--- a/Handler/TodaysProfilesTask.hs
+++ b/Handler/TodaysProfilesTask.hs
@@ -8,6 +8,7 @@ import Import
 
 import qualified Control.Exception.Lifted as EL
 import Data.Maybe (fromJust)
+import Croniker.Types (OauthCredentials(OauthCredentials))
 
 import Model.Profile (allProfilesForUpdate)
 import qualified Croniker.Time as CT
@@ -35,12 +36,13 @@ updateProfile (Entity profileId (Profile{profileName, profileUserId, profilePict
             let username = userTwitterUsername user
             let accessKey = t2b $ userTwitterOauthToken user
             let accessSecret = t2b $ userTwitterOauthTokenSecret user
+            let credentials = OauthCredentials twitterConsumerKey twitterConsumerSecret accessKey accessSecret
             liftIO $ do
                 logger username $ "Updating name to " <> profileName
-                updateTwitterName profileName twitterConsumerKey twitterConsumerSecret accessKey accessSecret
+                updateTwitterName profileName credentials
                 when (isJust profilePicture) $ do
                     logger username "Updating picture"
-                    updateTwitterPicture (fromJust profilePicture) twitterConsumerKey twitterConsumerSecret accessKey accessSecret
+                    updateTwitterPicture (fromJust profilePicture) credentials
             runDB $ update profileId [ProfileSent =. True]
 
 logger :: Text -> Text -> IO ()

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -15,6 +15,7 @@ library
     hs-source-dirs: ., app, src
     exposed-modules: Application
                      Croniker.Time
+                     Croniker.Types
                      Croniker.UrlParser
                      Data.TZLabel
                      Foundation

--- a/src/Croniker/Types.hs
+++ b/src/Croniker/Types.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Croniker.Types
+    ( OauthCredentials(OauthCredentials)
+    , toOauth1Auth
+    ) where
+
+import Import.NoFoundation
+
+import qualified Network.Wreq as W
+
+data OauthCredentials = OauthCredentials
+    { oauthKey :: ByteString
+    , oauthSecret :: ByteString
+    , oauthUserKey :: ByteString
+    , oauthUserSecret :: ByteString
+    }
+
+toOauth1Auth :: OauthCredentials -> W.Auth
+toOauth1Auth (OauthCredentials{oauthKey, oauthSecret, oauthUserKey, oauthUserSecret}) = W.oauth1Auth
+    oauthKey
+    oauthSecret
+    oauthUserKey
+    oauthUserSecret

--- a/src/Croniker/Types.hs
+++ b/src/Croniker/Types.hs
@@ -2,7 +2,8 @@
 
 module Croniker.Types
     ( OauthCredentials(OauthCredentials)
-    , toOauth1Auth
+    , OauthReader
+    , runOauthReader
     ) where
 
 import Import.NoFoundation
@@ -15,6 +16,11 @@ data OauthCredentials = OauthCredentials
     , oauthUserKey :: ByteString
     , oauthUserSecret :: ByteString
     }
+
+type OauthReader = ReaderT W.Auth IO
+
+runOauthReader :: MonadIO m => OauthReader a -> OauthCredentials -> m a
+runOauthReader reader creds = liftIO $ runReaderT reader (toOauth1Auth creds)
 
 toOauth1Auth :: OauthCredentials -> W.Auth
 toOauth1Auth (OauthCredentials{oauthKey, oauthSecret, oauthUserKey, oauthUserSecret}) = W.oauth1Auth

--- a/src/TwitterClient.hs
+++ b/src/TwitterClient.hs
@@ -6,21 +6,20 @@ module TwitterClient
 import Import
 
 import Control.Lens ((.~), (&), (?~))
-import Network.Wreq (FormParam((:=)), auth, defaults, postWith, param, oauth1Auth)
+import Network.Wreq (FormParam((:=)), auth, defaults, postWith, param)
+import Croniker.Types (OauthCredentials, toOauth1Auth)
 
 -- https://dev.twitter.com/rest/reference/post/account/update_profile
-updateTwitterName :: Text -> ByteString -> ByteString -> ByteString -> ByteString -> IO ()
-updateTwitterName newName consumerKey consumerSecret accessKey accessSecret = do
+updateTwitterName :: Text -> OauthCredentials -> IO ()
+updateTwitterName newName oauthCredentials = do
     let url = "https://api.twitter.com/1.1/account/update_profile.json"
-    let twitterAuth = oauth1Auth consumerKey consumerSecret accessKey accessSecret
-    let opts = defaults & param "name" .~ [newName] & auth ?~ twitterAuth
+    let opts = defaults & param "name" .~ [newName] & auth ?~ (toOauth1Auth oauthCredentials)
     -- Null because we don't send anything in the post body
     void $ postWith opts url Null
 
 -- https://dev.twitter.com/rest/reference/post/account/update_profile_image
-updateTwitterPicture :: Text -> ByteString -> ByteString -> ByteString -> ByteString -> IO ()
-updateTwitterPicture b64image consumerKey consumerSecret accessKey accessSecret = do
+updateTwitterPicture :: Text -> OauthCredentials -> IO ()
+updateTwitterPicture b64image oauthCredentials = do
     let url = "https://api.twitter.com/1.1/account/update_profile_image.json"
-    let twitterAuth = oauth1Auth consumerKey consumerSecret accessKey accessSecret
-    let opts = defaults & auth ?~ twitterAuth
+    let opts = defaults & auth ?~ (toOauth1Auth oauthCredentials)
     void $ postWith opts url ["image" := b64image]

--- a/src/TwitterClient.hs
+++ b/src/TwitterClient.hs
@@ -7,19 +7,22 @@ import Import
 
 import Control.Lens ((.~), (&), (?~))
 import Network.Wreq (FormParam((:=)), auth, defaults, postWith, param)
-import Croniker.Types (OauthCredentials, toOauth1Auth)
+
+import Croniker.Types (OauthReader)
 
 -- https://dev.twitter.com/rest/reference/post/account/update_profile
-updateTwitterName :: Text -> OauthCredentials -> IO ()
-updateTwitterName newName oauthCredentials = do
+updateTwitterName :: Text -> OauthReader ()
+updateTwitterName newName = do
+    oauth <- ask
     let url = "https://api.twitter.com/1.1/account/update_profile.json"
-    let opts = defaults & param "name" .~ [newName] & auth ?~ (toOauth1Auth oauthCredentials)
+    let opts = defaults & param "name" .~ [newName] & auth ?~ oauth
     -- Null because we don't send anything in the post body
-    void $ postWith opts url Null
+    void $ liftIO $ postWith opts url Null
 
 -- https://dev.twitter.com/rest/reference/post/account/update_profile_image
-updateTwitterPicture :: Text -> OauthCredentials -> IO ()
-updateTwitterPicture b64image oauthCredentials = do
+updateTwitterPicture :: Text -> OauthReader ()
+updateTwitterPicture b64image = do
+    oauth <- ask
     let url = "https://api.twitter.com/1.1/account/update_profile_image.json"
-    let opts = defaults & auth ?~ (toOauth1Auth oauthCredentials)
-    void $ postWith opts url ["image" := b64image]
+    let opts = defaults & auth ?~ oauth
+    void $ liftIO $ postWith opts url ["image" := b64image]


### PR DESCRIPTION
This moves `OauthCredentials` to the edge of the computation: instead of
being explicitly passed to `updateTwitterName` and `updateTwitterPicture`,
the functions `ask` their context for the credentials. Only
`runOauthReader` actually takes in the built credentials, and they're
available to each function in the `OauthReader` computation.