### PR TITLE
Twitter disallows monikers that contain "Twitter"

### DIFF
--- a/Handler/Profile.hs
+++ b/Handler/Profile.hs
@@ -128,7 +128,12 @@ prettyTime :: (FormatTime t) => t -> String
 prettyTime = formatTime defaultTimeLocale "%B %d, %Y"
 
 nameField :: Field Handler Text
-nameField = check maxLength textField
+nameField = check doesNotContainTwitter $ check maxLength textField
+
+doesNotContainTwitter :: Text -> Either Text Text
+doesNotContainTwitter name
+    | "twitter" `isInfixOf` (toLower name) = Left "Twitter doesn't allow monikers that contain \"Twitter\""
+    | otherwise = Right name
 
 maxLength :: Text -> Either Text Text
 maxLength name


### PR DESCRIPTION
The error:

    403 Forbidden
    Account update failed: Name can't include "twitter"