### PR TITLE
Use Parsec to detect URLs in monikers

### DIFF
--- a/Handler/Profile.hs
+++ b/Handler/Profile.hs
@@ -18,6 +18,7 @@ import Helper.Request (fromMaybe404)
 import Helper.TextConversion (b2t)
 import qualified Model.Profile as M
 import qualified Croniker.Time as CT
+import qualified Croniker.UrlParser as CUP
 
 instance ToMarkup Day where
   toMarkup = toMarkup . show
@@ -129,12 +130,17 @@ prettyTime :: (FormatTime t) => t -> String
 prettyTime = formatTime defaultTimeLocale "%B %d, %Y"
 
 nameField :: Field Handler Text
-nameField = check doesNotContainTwitter $ check maxLength textField
+nameField = check doesNotContainUrl $ check doesNotContainTwitter $ check maxLength textField
 
 doesNotContainTwitter :: Text -> Either Text Text
 doesNotContainTwitter name
     | "twitter" `isInfixOf` (toLower name) = Left "Twitter doesn't allow monikers that contain \"Twitter\""
     | otherwise = Right name
+
+doesNotContainUrl :: Text -> Either Text Text
+doesNotContainUrl name = if CUP.containsUrl name
+                            then Left "Twitter doesn't allow URLs in monikers"
+                            else Right name
 
 maxLength :: Text -> Either Text Text
 maxLength name

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -15,6 +15,7 @@ library
     hs-source-dirs: ., app, src
     exposed-modules: Application
                      Croniker.Time
+                     Croniker.UrlParser
                      Data.TZLabel
                      Foundation
                      Handler.ChooseTimezone
@@ -112,6 +113,7 @@ library
                  , conduit-extra
                  , http-client
                  , lifted-base
+                 , parsec
 
 executable         croniker
     if flag(library-only)

--- a/src/Croniker/UrlParser.hs
+++ b/src/Croniker/UrlParser.hs
@@ -1,0 +1,29 @@
+module Croniker.UrlParser
+    ( containsUrl
+    ) where
+
+import Prelude
+import Data.Monoid ((<>))
+import qualified Data.Text as T
+import Data.Either (isRight)
+import Text.ParserCombinators.Parsec
+
+type Url = String
+
+containsUrl :: T.Text -> Bool
+containsUrl t = or $ map isUrl (words $ T.unpack $ T.toLower t)
+
+isUrl :: String -> Bool
+isUrl s = isRight $ parse url "" s
+
+url :: Parser Url
+url = do
+    a <- many1 alphaNum
+    b <- string "."
+    c <- tld
+    return $ a <> b <> c
+
+-- Twitter allows most 2-letter TLDs, but not `.co`
+tld :: Parser String
+tld = try (count 3 alphaNum)
+    <|> string "co"


### PR DESCRIPTION
Twitter does not allow URLs. It does allow things like:

* `url.comelse`
* `@.com`