### PR TITLE
Ensure that usernames are not just spaces

### DIFF
--- a/Handler/Profile.hs
+++ b/Handler/Profile.hs
@@ -107,7 +107,7 @@ profileForm tomorrow userId extra = do
         ^{display dayView}
     |]
     let profile = Profile
-                    <$> nameRes
+                    <$> (normalize <$> nameRes)
                     <*> dayRes
                     <*> pure userId
                     <*> pure Nothing
@@ -154,6 +154,9 @@ validLength name
     | length (T.strip name) == 0 = Left "Usernames cannot be only spaces"
     | length (T.strip name) > 20 = Left "Twitter doesn't allow profiles longer than 20 characters"
     | otherwise = Right name
+
+normalize :: Text -> Text
+normalize = T.strip
 
 dateField :: Day -> Field Handler Day
 dateField tomorrow = check (futureDate tomorrow) dayField

--- a/Handler/Profile.hs
+++ b/Handler/Profile.hs
@@ -13,6 +13,7 @@ import Text.Blaze (ToMarkup, toMarkup)
 import qualified Data.ByteString.Base64 as B64
 import Data.Conduit.Binary (sinkLbs)
 import qualified Data.ByteString.Lazy as L
+import qualified Data.Text as T
 
 import Helper.Request (fromMaybe404)
 import Helper.TextConversion (b2t)
@@ -136,7 +137,7 @@ prettyTime :: (FormatTime t) => t -> String
 prettyTime = formatTime defaultTimeLocale "%B %d, %Y"
 
 nameField :: Field Handler Text
-nameField = check doesNotContainUrl $ check doesNotContainTwitter $ check maxLength textField
+nameField = check doesNotContainUrl $ check doesNotContainTwitter $ check validLength textField
 
 doesNotContainTwitter :: Text -> Either Text Text
 doesNotContainTwitter name
@@ -148,9 +149,10 @@ doesNotContainUrl name
     | CUP.containsUrl name = Left "Twitter doesn't allow URLs in monikers"
     | otherwise = Right name
 
-maxLength :: Text -> Either Text Text
-maxLength name
-    | length name > 20 = Left "Twitter doesn't allow profiles longer than 20 characters"
+validLength :: Text -> Either Text Text
+validLength name
+    | length (T.strip name) == 0 = Left "Usernames cannot be only spaces"
+    | length (T.strip name) > 20 = Left "Twitter doesn't allow profiles longer than 20 characters"
     | otherwise = Right name
 
 dateField :: Day -> Field Handler Day


### PR DESCRIPTION
Twitter also strips spaces before checking length, so it would allow 20 chars surrounded by 40 chars of whitespace. Now Croniker does the same thing.