### PR TITLE
Use applicative-style form for Profile

### DIFF
--- a/sass/_errors.scss
+++ b/sass/_errors.scss
@@ -1,3 +1,3 @@
-.form-errors {
+form .errors {
   color: $red;
 }

--- a/static/css/application.css
+++ b/static/css/application.css
@@ -404,7 +404,7 @@ footer, .push {
 footer {
   text-align: center; }
 
-.form-errors {
+form .errors {
   color: #ed5446; }
 
 .page-login {


### PR DESCRIPTION
The monadic style wasn't necessary and we can `fmap` the normalization functions through the `areq`/`aopt` functions.

Of note is the `Nothing <$ aopt fileField ...`, which always sets the result of the file field to `Nothing`. `withPossibleProfilePicture` will set the file field to an actual Base64-encoded value later in the POST handler.