### PR TITLE
Show a friendly error if a date is already taken

### DIFF
--- a/Model/User.hs
+++ b/Model/User.hs
@@ -2,6 +2,7 @@
 
 module Model.User
     ( authenticateUser
+    , takenDays
     ) where
 
 import Import.NoFoundation
@@ -24,6 +25,9 @@ authenticateUser Creds{credsExtra} = do
         updateUser userId = do
             update userId (updateStatements credsExtra)
             return (Authenticated userId)
+
+takenDays :: UserId -> DB [Day]
+takenDays userId = map (profileDate . entityVal) <$> selectList [ProfileUserId ==. userId] []
 
 credsToUser :: [(Text, Text)] -> Maybe User
 credsToUser credsExtra = User


### PR DESCRIPTION
Previously, attempting to schedule a Profile on a date that already had a Profile would show a 500 error with a SQL error (since there's a unique index in the DB).

Now it shows an error message instead, which lets the user know what's happening and how to fix it.

Fixes https://github.com/gabebw/croniker/issues/53