### PR TITLE
Ensure that URLs are really URLs

### DIFF
--- a/croniker.cabal
+++ b/croniker.cabal
@@ -115,7 +115,7 @@ library
                  , conduit-extra
                  , http-client
                  , lifted-base
-                 , parsec
+                 , tld
 
 executable         croniker
     if flag(library-only)
@@ -152,6 +152,9 @@ test-suite test
     main-is:           Spec.hs
     hs-source-dirs:    test
     ghc-options:       -Wall
+
+    other-modules: Croniker.MonikerNormalizationSpec
+                 , Croniker.UrlParserSpec
 
     extensions: TemplateHaskell
                 QuasiQuotes

--- a/src/Croniker/UrlParser.hs
+++ b/src/Croniker/UrlParser.hs
@@ -5,26 +5,17 @@ module Croniker.UrlParser
 import Prelude
 import Data.Monoid ((<>))
 import qualified Data.Text as T
-import Data.Either (isRight)
-import Text.Parsec
-import Text.Parsec.Text (Parser)
-
-type Url = String
+import Data.Maybe (isJust)
+import Network.URI.TLD (parseTLDText)
 
 containsUrl :: T.Text -> Bool
-containsUrl = any isUrl . T.words . T.toLower
+containsUrl = any isUrl . T.words
 
 isUrl :: T.Text -> Bool
-isUrl = isRight . parse url ""
+isUrl = isJust . parseTLDText . withHTTP
 
-url :: Parser Url
-url = do
-    a <- many1 alphaNum
-    b <- string "."
-    c <- tld
-    return $ a <> b <> c
-
--- Twitter allows most 2-letter TLDs, but not `.co`
-tld :: Parser String
-tld = try (count 3 alphaNum)
-    <|> string "co"
+withHTTP :: T.Text -> T.Text
+withHTTP t
+  | "http://" `T.isPrefixOf` t = t
+  | "https://" `T.isPrefixOf` t = t
+  | otherwise = "http://" <> t

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,6 +13,7 @@ extra-deps:
 - wreq-sb-0.4.0.0
 - yesod-auth-oauth-1.4.0.2
 - heroku-persistent-0.1.0
+- tld-0.3.0.0
 
 # Override default flag values for local packages and extra-deps
 flags:

--- a/test/Croniker/UrlParserSpec.hs
+++ b/test/Croniker/UrlParserSpec.hs
@@ -1,0 +1,45 @@
+module Croniker.UrlParserSpec
+    ( main
+    , spec
+    ) where
+
+import Prelude
+import Test.Hspec
+
+import Croniker.UrlParser (containsUrl)
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = describe "Croniker.UrlParser" $ do
+    describe "containsUrl" $ do
+        it "returns true for strings that contain URLs" $ do
+            containsUrl "hello from something.com" `shouldBe` True
+
+        it "returns true for strings that contain mixed-case URLs" $ do
+            containsUrl "hello from SOMEthing.CoM" `shouldBe` True
+
+        it "returns true for strings that contain fancy URLs" $ do
+            containsUrl "hello from something.club" `shouldBe` True
+
+        it "returns true for strings that contain fancier URLs" $ do
+            containsUrl "hello from something.co.uk" `shouldBe` True
+
+        it "returns true for strings that are only URLs" $ do
+            containsUrl "something.com" `shouldBe` True
+
+        it "returns true for strings with http://-prefixed URLs" $ do
+            containsUrl "https://something.com" `shouldBe` True
+
+        it "returns true for strings with https://-prefixed URLs" $ do
+            containsUrl "http://something.com" `shouldBe` True
+
+        it "returns false for strings with nothing that looks like a URL" $ do
+            containsUrl "hello" `shouldBe` False
+
+        it "returns false for strings that contain a file extension" $ do
+            containsUrl "hello.tar.gz" `shouldBe` False
+
+        it "returns false for non-URLs that start with 'http'" $ do
+            containsUrl "httphi" `shouldBe` False


### PR DESCRIPTION
The previous solution's simple parsing meant that names like `adarsh.tar.gz` (which is not a valid URL) was interpreted as a URL.

Now we use the tld library to ensure that only real URLs are parsed as such.

We must add `http://` to each possible URL before parsing it or else `parseTLDText` always returns `Nothing`.

Fixes #52.