### PR TITLE
Default to the next available date

### DIFF
--- a/sass/base/_forms.scss
+++ b/sass/base/_forms.scss
@@ -13,7 +13,6 @@ legend {
 }
 
 label {
-  display: block;
   font-weight: 600;
   margin-bottom: $small-spacing / 2;
 }
@@ -82,4 +81,10 @@ select {
   margin-bottom: $base-spacing;
   max-width: 100%;
   width: auto;
+}
+
+.tooltip {
+  color: $medium-gray;
+  display: inline;
+  margin-left: $small-spacing;
 }

--- a/static/css/application.css
+++ b/static/css/application.css
@@ -187,7 +187,6 @@ legend {
   padding: 0; }
 
 label {
-  display: block;
   font-weight: 600;
   margin-bottom: 0.375em; }
 
@@ -245,6 +244,11 @@ select {
   margin-bottom: 1.5em;
   max-width: 100%;
   width: auto; }
+
+.tooltip {
+  color: #999;
+  display: inline;
+  margin-left: 0.75em; }
 
 ul,
 ol {


### PR DESCRIPTION
The "Date" field now defaults to the first day in the next 365 days (not including today) that does _not_ have a profile scheduled. For example:

* if nothing is scheduled for today, it defaults to tomorrow.
* if nothing is scheduled for tomorrow, it defaults to tomorrow.
* if there are profiles scheduled for the next 7 days, it defaults to 8 days from now.

If the next 365 days are all taken, it falls back to tomorrow and the user will have to manually select a date from the date picker.

The SQL uses `generate_series` to generate a temporary table containing the next 365 days, does a `LEFT OUTER JOIN` with `profile.date`, then selects the first generated date where `profile.date` is NULL (meaning that there's no profile scheduled for that day).