### PR TITLE
Update deploy script to use heroku-container-tools

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -15,4 +15,5 @@ if [ "$(uname)" = "Darwin" ]; then
   eval "$(docker-machine env default)"
 fi
 
-heroku docker:release --remote "$1"
+heroku container:login
+heroku container:push --remote "$1"

--- a/bin/setup
+++ b/bin/setup
@@ -13,8 +13,8 @@ if ! command -v docker-compose > /dev/null; then
   exit 1
 fi
 
-if ! heroku plugins | grep -Fq heroku-docker; then
-  heroku plugins:install heroku-docker
+if ! heroku plugins | grep -Fq heroku-container-tools; then
+  heroku plugins:install heroku-container-tools
 fi
 
 heroku git:remote --remote staging --app croniker-staging


### PR DESCRIPTION
The [heroku-container-tools plugin][0] has replaced heroku-docker.

It uses the (beta) Heroku Docker registry.

[0]: https://github.com/heroku/heroku-container-tools