### PR TITLE
Use Haskell, not SQL, to find the next free date

### DIFF
--- a/Handler/Profile.hs
+++ b/Handler/Profile.hs
@@ -10,7 +10,6 @@ import Import
 import Data.Conduit.Binary (sinkLbs)
 import Data.Maybe (fromJust)
 import Data.Time.Format (FormatTime)
-import Database.Persist.Sql (Single(..))
 import Text.Blaze (ToMarkup, toMarkup)
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Lazy as L
@@ -31,7 +30,7 @@ getProfileR = do
     euser@(Entity userId user) <- prerequisites
     tomorrow <- CT.localTomorrow user
     takenDays <- runDB $ U.takenDays tomorrow userId
-    nextFreeDay <- (maybe tomorrow unSingle) <$> runDB (U.nextFreeDay userId)
+    nextFreeDay <- runDB $ U.nextFreeDay tomorrow userId
     widget <- fst <$> (generateFormPost $ profileForm nextFreeDay takenDays tomorrow userId)
     profilesTemplate euser widget
 
@@ -40,7 +39,7 @@ postProfileR = do
     euser@(Entity userId user) <- prerequisites
     tomorrow <- CT.localTomorrow user
     takenDays <- runDB $ U.takenDays tomorrow userId
-    nextFreeDay <- (maybe tomorrow unSingle) <$> runDB (U.nextFreeDay userId)
+    nextFreeDay <- runDB $ U.nextFreeDay tomorrow userId
     (resultWithoutProfilePicture, formWidget) <- fst <$> (runFormPost $ profileForm nextFreeDay takenDays tomorrow userId)
     result <- withPossibleProfilePicture resultWithoutProfilePicture
 


### PR DESCRIPTION
The SQL query was complex and hard to understand.

The Haskell is much easier to understand which, given the low usage of this app, is more important than any imagined performance gains.

Model.User.nextFreeDay now:

* Generates a list of the next 365 `Day`s,
* Selects future profile dates from the given user's profiles,
* Finds the first `Day` in the next year that _doesn't_ match a profile date.
* If all of the dates are taken, it falls back to tomorrow and lets the user find a free date.