### PR TITLE
Use intermediate data structure for Profile form

### DIFF
--- a/Helper/TextConversion.hs
+++ b/Helper/TextConversion.hs
@@ -1,11 +1,14 @@
 module Helper.TextConversion
     ( b2t
+    , base64Encode
     , t2b)
     where
 
 import Prelude
 
+import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Char8 as BSC
+import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 
@@ -14,3 +17,6 @@ b2t = T.decodeLatin1
 
 t2b :: T.Text -> BSC.ByteString
 t2b = T.encodeUtf8
+
+base64Encode :: BSL.ByteString -> T.Text
+base64Encode = b2t . B64.encode . BSL.toStrict

--- a/Model/Profile.hs
+++ b/Model/Profile.hs
@@ -2,11 +2,35 @@ module Model.Profile
     ( futureProfilesFor
     , allProfilesForUpdate
     , findProfileFor
+    , addProfile
+    , FormProfile(..)
     ) where
 
 import Import
 
 import Croniker.Time
+import Data.Conduit.Binary (sinkLbs)
+import Helper.TextConversion (base64Encode)
+
+data FormProfile = FormProfile
+    { profileName :: Text
+    , profileDate :: Day
+    , profileUserId :: UserId
+    , profilePicture :: Maybe FileInfo
+    , profileSent :: Bool
+    }
+
+addProfile :: FormProfile -> Handler ()
+addProfile (FormProfile name date userId picture sent) = do
+    b64Picture <- base64Bytes picture
+    void $ runDB $ insert $ Profile name date userId b64Picture sent
+
+-- If a picture was uploaded, base64-encode it.
+base64Bytes :: Maybe FileInfo -> Handler (Maybe Text)
+base64Bytes Nothing = return Nothing
+base64Bytes (Just fi) = do
+    fileBytes <- runResourceT $ fileSource fi $$ sinkLbs
+    return $ Just $ base64Encode fileBytes
 
 findProfileFor :: UserId -> ProfileId -> DB (Maybe (Entity Profile))
 findProfileFor userId profileId = selectFirst [ProfileUserId ==. userId, ProfileId ==. profileId] []


### PR DESCRIPTION
A `Profile` can have an (optional) Base64-encoded picture. The user uploads a picture, Croniker Base64-encodes its bytes, and stores those encoded bytes in the database.

However, an uploaded picture is represented as a `FileInfo`. `Profile` wants a `Maybe Text` for its `picture` field, and so its applicative `Form` must turn the `FileInfo` into a `Maybe Text` or else it won't compile.

Turning that `FileInfo` into the actual uploaded bytes is unsafe, since the uploaded file may have been deleted on the server before Yesod can process it.  Since the operation is unsafe, it's very difficult (impossible?) to pull out the bytes in an applicative `Form`.

The solution: don't build the form around `Profile` -- build it around an easier-to-use type instead, then post-process into a `Profile`. That's exactly what `FormProfile` is. It accepts a `FileInfo`, so Croniker doesn't need to do complex unsafe operations in the applicative `Form`. Once the form is successfully uploaded, `addProfile` turns the `FormProfile` into a `Profile` and inserts it into the database. Since `addProfile` runs in a `Handler`, it can perform unsafe operations like Base64-encoding the uploaded file, then hand the Base64-encoded bytes to `Profile` before it's inserted into the database.

Thank you to:

* https://github.com/rab206/fp-cv-file-server/blob/d9a7fb5446cde68ade71b31abc35a4d5c1abfe34/Foundation.hs
* https://github.com/rab206/fp-cv-file-server/blob/d9a7fb5446cde68ade71b31abc35a4d5c1abfe34/Handler/Home.hs