### PR TITLE
Use Stack LTS 6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM thoughtbot/heroku-haskell-stack
+FROM thoughtbot/heroku-haskell-stack:lts-6.3
 
 # Add a /app/GIT_HEAD_REF file with the git commit SHA that is currently
 # deployed.

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -80,7 +80,7 @@ library
                  , persistent-template           >= 2.0        && < 2.3
                  , template-haskell
                  , shakespeare                   >= 2.0        && < 2.1
-                 , hjsmin                        >= 0.1        && < 0.2
+                 , hjsmin                        >= 0.1
                  , monad-control                 >= 0.3        && < 1.1
                  , wai-extra                     >= 3.0        && < 3.1
                  , yaml                          >= 0.8        && < 0.9
@@ -88,7 +88,7 @@ library
                  , directory                     >= 1.1        && < 1.3
                  , warp                          >= 3.0        && < 3.3
                  , data-default
-                 , aeson                         >= 0.6        && < 0.11
+                 , aeson                         >= 0.6
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4
                  , fast-logger                   >= 2.2        && < 2.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available
-resolver: lts-5.17
+resolver: lts-6.3
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
It's OK to remove the version constraints because a specific Stack LTS release always uses one version of each package, and guarantees that all packages in a release work together.

Croniker was using LTS 5.17.

LTS 6.3 is the latest version available for this Dockerfile: https://github.com/thoughtbot/docker-heroku-haskell-stack/blob/master/Dockerfile

The package difference between 5.17 and 6.3: https://www.stackage.org/diff/lts-5.17/lts-6.3