### PR TITLE
A moniker is optional

### DIFF
--- a/Form/Profile.hs
+++ b/Form/Profile.hs
@@ -10,8 +10,8 @@ import qualified Model.Profile as P
 
 profileForm :: Day -> [Day] -> Day -> Form P.FormProfile
 profileForm nextFreeDay takenDays tomorrow = renderDivs $ P.FormProfile
-    <$> fmap CMN.normalize
-            (areq
+    <$> fmap normalizeMaybe
+            (aopt
                 monikerField
                 (fs "New moniker" [("maxlength", "20"), ("autofocus", "autofocus")])
                 Nothing)
@@ -20,6 +20,8 @@ profileForm nextFreeDay takenDays tomorrow = renderDivs $ P.FormProfile
             ("Date" { fsTooltip = Just "Defaults to the next available date" })
             (Just nextFreeDay)
     <*> aopt fileField "Profile picture (optional)" Nothing
+    where
+        normalizeMaybe = fmap CMN.normalize
 
 fs :: Text -> [(Text, Text)] -> FieldSettings site
 fs label attrs = FieldSettings

--- a/Handler/Profile.hs
+++ b/Handler/Profile.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Handler.Profile
@@ -39,10 +40,15 @@ postProfileR = do
     (result, formWidget) <- fst <$> (runFormPost $ profileForm nextFreeDay takenDays tomorrow)
 
     case result of
-        FormSuccess formProfile  -> do
-            P.addProfile userId formProfile
-            setMessage "Profile created"
-            redirect ProfileR
+        FormSuccess formProfile@P.FormProfile{profileMoniker, profilePicture} -> do
+            if isJust profileMoniker || isJust profilePicture
+               then do
+                   P.addProfile userId formProfile
+                   setMessage "Profile created"
+                   redirect ProfileR
+                else do
+                   setMessage "Please set a moniker or a picture"
+                   profilesTemplate euser formWidget
         _ -> do
             setMessage "Oops, something went wrong"
             profilesTemplate euser formWidget

--- a/Handler/UpdateProfilesTask.hs
+++ b/Handler/UpdateProfilesTask.hs
@@ -39,7 +39,8 @@ updateProfile (Entity profileId (Profile{profileMoniker, profileUserId, profileP
         (Just user) -> do
             let username = userTwitterUsername user
             let computation = do
-                updateMoniker profileMoniker >>= logger username
+                forM_ profileMoniker $ \moniker ->
+                    updateMoniker moniker >>= logger username
                 forM_ profilePicture $ \picture ->
                     updatePicture picture >>= logger username
             runOauthReader computation =<< oauthCredentials user

--- a/Model/Profile.hs
+++ b/Model/Profile.hs
@@ -13,7 +13,7 @@ import Data.Conduit.Binary (sinkLbs)
 import Helper.TextConversion (base64Encode)
 
 data FormProfile = FormProfile
-    { profileMoniker :: Text
+    { profileMoniker :: Maybe Text
     , profileDate :: Day
     , profilePicture :: Maybe FileInfo
     }

--- a/config/models
+++ b/config/models
@@ -15,7 +15,7 @@ User
     UniqueUser twitterUserId
     deriving Typeable Show
 Profile
-    moniker Text
+    moniker Text Maybe
     date Day
     userId UserId
     picture Text Maybe

--- a/templates/profiles.hamlet
+++ b/templates/profiles.hamlet
@@ -11,12 +11,13 @@
         $else
             <ul>
                 <div.banner>All changes will happen at 1am on the scheduled day.
-                $forall (Entity profileId (Profile name date _ picture sent)) <- allProfiles
+                $forall (Entity profileId (Profile mname date _ mpicture sent)) <- allProfiles
                     <li.profile>
-                        $maybe b64data <- picture
+                        $maybe b64data <- mpicture
                             <div.profile-picture>
                                 <img src="data:;base64,#{b64data}">
-                        <strong>#{name}
+                        $maybe name <- mname
+                            <strong>#{name}
                         <div>#{prettyTime date}
                         $if sent
                             <div>Successfully sent to Twitter


### PR DESCRIPTION
Previously, users had to provide a moniker, and could also provide a picture if they chose.

Now a moniker is no longer required, though a user must provide either a moniker or a picture (or both). I.e., users can now change just their profile picture without changing their moniker.