### PR TITLE
Enforce a more explicit grid on the profiles index

### DIFF
--- a/Handler/Profile.hs
+++ b/Handler/Profile.hs
@@ -47,7 +47,7 @@ postProfileR = do
                    setMessage "Profile created"
                    redirect ProfileR
                 else do
-                   setMessage "Please set a moniker or a picture"
+                   setMessage "Please set a moniker, description, or picture"
                    profilesTemplate euser formWidget
         _ -> do
             setMessage "Oops, something went wrong"
@@ -76,6 +76,13 @@ profilesTemplate euser profileWidget = do
     defaultLayout $ do
         setTitle "Croniker"
         $(widgetFile "profiles")
+
+textFieldsTemplate :: Profile -> Widget
+textFieldsTemplate Profile{profileMoniker} = [whamlet|
+        $maybe name <- profileMoniker
+            <p>
+                <strong>#{name}
+    |]
 
 prettyTime :: (FormatTime t) => t -> String
 prettyTime = formatTime defaultTimeLocale "%B %d, %Y"

--- a/sass/pages/_profiles.scss
+++ b/sass/pages/_profiles.scss
@@ -1,4 +1,9 @@
 .page-profiles {
+  $profile-columns: 5;
+  $picture-columns: 1;
+  $with-picture-columns: $profile-columns - $picture-columns;
+  $without-picture-columns: $profile-columns;
+
   .banner {
     margin-bottom: $large-spacing;
   }
@@ -9,16 +14,17 @@
 
   .profiles {
     @include shift(1);
-    @include span-columns(5);
+    @include span-columns($profile-columns);
   }
 
   .profile {
-    @include span-columns(5 of 5);
+    @include span-columns($profile-columns of $profile-columns);
 
     margin-bottom: $large-spacing;
 
-    form, button {
-      display: inline;
+    form, .date {
+      clear: both;
+      float: left;
     }
 
     button {
@@ -40,7 +46,7 @@
   }
 
   .profile-picture {
-    @include span-columns(1 of 5);
+    @include span-columns($picture-columns of $profile-columns);
 
     img {
       $small-twitter-profile-size: 72px;
@@ -49,5 +55,15 @@
       min-width: $small-twitter-profile-size;
       width: $small-twitter-profile-size;
     }
+  }
+
+  .updated-fields-with-picture {
+    @include span-columns($with-picture-columns of $profile-columns);
+    @include omega;
+  }
+
+  .updated-fields-without-picture {
+    @include span-columns($without-picture-columns);
+    @include omega;
   }
 }

--- a/static/css/application.css
+++ b/static/css/application.css
@@ -443,8 +443,9 @@ form .errors {
   margin-bottom: 3em; }
   .page-profiles .profile:last-child {
     margin-right: 0; }
-  .page-profiles .profile form, .page-profiles .profile button {
-    display: inline; }
+  .page-profiles .profile form, .page-profiles .profile .date {
+    clear: both;
+    float: left; }
   .page-profiles .profile button {
     background-color: white;
     border-bottom: 1px solid #00cee3;
@@ -469,6 +470,22 @@ form .errors {
     height: 72px;
     min-width: 72px;
     width: 72px; }
+.page-profiles .updated-fields-with-picture {
+  float: left;
+  display: block;
+  margin-right: 5.85151%;
+  width: 78.8297%;
+  margin-right: 0; }
+  .page-profiles .updated-fields-with-picture:last-child {
+    margin-right: 0; }
+.page-profiles .updated-fields-without-picture {
+  float: left;
+  display: block;
+  margin-right: 2.35765%;
+  width: 40.29137%;
+  margin-right: 0; }
+  .page-profiles .updated-fields-without-picture:last-child {
+    margin-right: 0; }
 
 main {
   max-width: 68em;

--- a/templates/profiles.hamlet
+++ b/templates/profiles.hamlet
@@ -11,16 +11,19 @@
         $else
             <ul>
                 <div.banner>All changes will happen at 1am in your time zone on the scheduled day.
-                $forall (Entity profileId (Profile mname date _ mpicture sent)) <- allProfiles
+                $forall (Entity profileId p@(Profile _ date _ mpicture sent)) <- allProfiles
                     <li.profile>
                         $maybe b64data <- mpicture
                             <div.profile-picture>
                                 <img src="data:;base64,#{b64data}">
-                        $maybe name <- mname
-                            <strong>#{name}
-                        <div>#{prettyTime date}
+                            <div.updated-fields>
+                                ^{textFieldsTemplate p}
+                        $nothing
+                            <div.updated-fields-full>
+                                ^{textFieldsTemplate p}
                         $if sent
-                            <div>Successfully sent to Twitter
+                            <p>Successfully sent to Twitter
+                        <p.date>#{prettyTime date}
                         <form method=post action=@{DeleteProfileR profileId}>
                             <input type="hidden" name="_token" value="#{csrfToken}">
                             <button type="submit" value="">


### PR DESCRIPTION
The picture and the moniker are next to each other, but only the picture was in a grid column. This means that as more fields are added, they could flow around the picture since they won't be in a grid column.

Now the picture is in its own column and the text fields are in their own column, so the text won't ever flow around the profile picture.

When there is no profile picture, the text (right now just the moniker) takes up all of the space available.

If there is a profile picture, the picture takes 1 column and the text takes the rest.