### PR TITLE
Move much more configuration into the environment

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,3 @@
+DATABASE_URL=postgres://croniker:croniker@localhost:5432/croniker_test
+LOG_LEVEL=debug
+SKIP_COMBINING=true

--- a/.sample.env
+++ b/.sample.env
@@ -1,0 +1,4 @@
+DATABASE_URL=postgres://croniker:croniker@localhost:5432/croniker
+# To log everything, set this to debug
+LOG_LEVEL=debug
+SKIP_COMBINING=true

--- a/bin/setup
+++ b/bin/setup
@@ -2,11 +2,26 @@
 
 set -e
 
+app=croniker
+
 stack install yesod-bin cabal-install --install-ghc
 stack build
-if ! psql -l | cut -d'|' -f1 | grep -qF croniker_development; then
-  createdb croniker_development
-fi
+
+createdb "$app" 2>/dev/null || true
+createdb "${app}_test" 2>/dev/null || true
+
+psql template1 >/dev/null <<SQL
+  DO
+  \$body\$
+    BEGIN
+      IF NOT EXISTS (SELECT * FROM pg_catalog.pg_user WHERE usename = '$app')
+      THEN CREATE USER $app WITH PASSWORD '$app';
+      END IF;
+    END
+  \$body\$;
+  GRANT ALL PRIVILEGES ON DATABASE $app to $app;
+  GRANT ALL PRIVILEGES ON DATABASE ${app}_test to $app;
+SQL
 
 if ! heroku plugins | grep -Fq heroku-container-tools; then
   heroku plugins:install heroku-container-tools
@@ -15,7 +30,10 @@ fi
 heroku git:remote --remote staging --app croniker-staging
 heroku git:remote --remote production --app croniker-production
 
-touch .env
+if ! [ -f .env ]; then
+  cp .sample.env .env
+fi
+
 for variable in TWITTER_CONSUMER_KEY TWITTER_CONSUMER_SECRET GOOGLE_API_KEY; do
   if ! grep -qF "$variable" .env; then
     heroku config --shell --remote staging | grep "$variable" >> .env

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,33 +1,14 @@
 # Values formatted like "_env:ENV_VAR_NAME:default_value" can be overridden by the specified environment variable.
 # See https://github.com/yesodweb/yesod/wiki/Configuration#overriding-configuration-values-with-environment-variables
 
-static-dir:     "_env:STATIC_DIR:static"
 host:           "_env:HOST:*4" # any IPv4 host
 port:           "_env:PORT:3000" # NB: The port `yesod devel` uses is distinct from this value. Set the `yesod devel` port from the command line.
 ip-from-header: "_env:IP_FROM_HEADER:false"
-
-# Default behavior: determine the application root from the request headers.
-# Uncomment to set an explicit approot
-#approot:        "_env:APPROOT:http://localhost:3000"
-
-# Optional values with the following production defaults.
-# In development, they default to the inverse.
-#
-# development: false
-# detailed-logging: false
-# should-log-all: false
-# reload-templates: false
-# mutable-static: false
-# skip-combining: false
+log-level: "_env:LOG_LEVEL:info"
+skip-combining: "_env:SKIP_COMBINING:false"
+database-url: "_env:DATABASE_URL:postgres://croniker:croniker@localhost:5432/croniker"
+database-pool-size: "_env:DATABASE_POOL_SIZE:10"
+mutable-static: "_env:MUTABLE_STATIC:false"
 
 # NB: If you need a numeric value (e.g. 123) to parse as a String, wrap it in single quotes (e.g. "_env:PGPASS:'123'")
 # See https://github.com/yesodweb/yesod/wiki/Configuration#parsing-numeric-values-as-strings
-
-database:
-  user:     "_env:PGUSER:\"\""
-  password: "_env:PGPASS:\"\""
-  host:     "_env:PGHOST:localhost"
-  port:     "_env:PGPORT:5432"
-  database: "_env:PGDATABASE:croniker_development"
-  poolsize: "_env:PGPOOLSIZE:10"
-#analytics: UA-YOURCODE

--- a/config/test-settings.yml
+++ b/config/test-settings.yml
@@ -1,2 +1,0 @@
-database:
-  database: croniker_LOWER_test

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -107,7 +107,7 @@ library
                  , blaze-markup
 
                  , base64-bytestring
-                 , dotenv
+                 , load-env
                  , heroku-persistent
                  , lens
                  , lens-aeson

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -50,10 +50,7 @@ type Form x = Html -> MForm (HandlerT App IO) (FormResult x, Widget)
 instance Yesod App where
     -- Controls the base of generated URLs. For more information on modifying,
     -- see: https://github.com/yesodweb/yesod/wiki/Overriding-approot
-    approot = ApprootRequest $ \app req ->
-        case appRoot $ appSettings app of
-            Nothing -> getApprootText guessApproot app req
-            Just root -> root
+    approot = ApprootRequest $ \app req -> getApprootText guessApproot app req
 
     -- Store session data on the client in encrypted cookies.
     -- `envClientSessionBackend` will use the `$SESSION_KEY` environment
@@ -116,12 +113,8 @@ instance Yesod App where
         -- Generate a unique filename based on the content itself
         genFileName lbs = "autogen-" ++ base64md5 lbs
 
-    -- What messages should be logged. The following includes all messages when
-    -- in development, and warnings and errors in production.
-    shouldLog app _source level =
-        appShouldLogAll (appSettings app)
-            || level == LevelWarn
-            || level == LevelError
+    -- Log messages only if app settings allow the message's log level.
+    shouldLog App{appSettings} _source level = appSettings `allowsLevel` level
 
     makeLogger = return . appLogger
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,7 @@ extra-deps:
 - heroku-0.1.2.3
 - wreq-sb-0.4.0.0
 - yesod-auth-oauth-1.4.0.2
-- heroku-persistent-0.1.0
+- heroku-persistent-0.2.0
 - tld-0.3.0.0
 
 # Override default flag values for local packages and extra-deps

--- a/templates/default-layout-wrapper.hamlet
+++ b/templates/default-layout-wrapper.hamlet
@@ -49,14 +49,3 @@ $doctype 5
       <p>Praise? Feedback? Let me know at #
         <a href="https://twitter.com/gabebw">@gabebw
         .
-
-    $maybe analytics <- appAnalytics $ appSettings master
-      <script>
-        if(!window.location.href.match(/localhost/)){
-          window._gaq = [['_setAccount','#{analytics}'],['_trackPageview'],['_trackPageLoadTime']];
-          (function() {
-          \  var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-          \  ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-          \  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-          })();
-        }

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -13,6 +13,7 @@ import Test.Hspec            as X
 import Text.Shakespeare.Text (st)
 import Yesod.Default.Config2 (ignoreEnv, loadAppSettings)
 import Yesod.Test            as X
+import LoadEnv (loadEnvFrom)
 
 runDB :: SqlPersistM a -> YesodExample App a
 runDB query = do
@@ -22,11 +23,11 @@ runDB query = do
 runDBWithApp :: App -> SqlPersistM a -> IO a
 runDBWithApp app query = runSqlPersistMPool query (appConnPool app)
 
-
 withApp :: SpecWith (TestApp App) -> Spec
 withApp = before $ do
+    loadEnvFrom ".env.test"
     settings <- loadAppSettings
-        ["config/test-settings.yml", "config/settings.yml"]
+        ["config/settings.yml"]
         []
         ignoreEnv
     foundation <- makeFoundation settings


### PR DESCRIPTION
There were a lot of optional configuration values, with confusing defaults (e.g. in development mode, it did not use the DATABASE_URL while in all other environments it did). Now more of the configuration is explicit and there's more development/production/test parity.

A lot of this is taken from https://pbrisbin.com/posts/tee-io_lessons_learned/.

Changes:

* Always read the database information from `$DATABASE_URL`. To that end, create local databases with known roles and names.
* Set the default log level to "info"
* Remove "shouldLogAll" setting in favor of always setting the log level. To log everything, set the log level to "debug".
* Use Pat's load-env package instead of dotenv, since load-env checks for file existence for me
* Use `#if DEVELOPMENT` based on https://github.com/pbrisbin/tee-io/commit/7ac70ffbe6a76bb21523cc72c7619b246999ee41
* Remove unused analytics-related code
* Always set `appStaticDir` to "static" instead of pulling it from the env
* Always guess the approot from headers
* Use `.env.test` instead of `test-settings.yml`