### PR TITLE
Add a basic smoke test for the root path

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,6 @@
 DATABASE_URL=postgres://croniker:croniker@localhost:5432/croniker_test
+GOOGLE_API_KEY=google_api_key
 LOG_LEVEL=debug
 SKIP_COMBINING=true
+TWITTER_CONSUMER_KEY=twitter_consumer_key
+TWITTER_CONSUMER_SECRET=twitter_consumer_secret

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -192,3 +192,4 @@ test-suite test
                  , classy-prelude-yesod
                  , aeson
                  , text >= 0.11 && < 2.0
+                 , load-env

--- a/test/Handler/RootSpec.hs
+++ b/test/Handler/RootSpec.hs
@@ -1,0 +1,19 @@
+module Handler.RootSpec
+    ( main
+    , spec
+    ) where
+
+import TestImport
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = withApp $ do
+    describe "Visiting the root path" $ do
+        describe "when signed out" $ do
+            it "shows a welcome message" $ do
+                get RootR
+
+                statusIs 200
+                bodyContains "Schedule changes to your Twitter name with Croniker"

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -5,7 +5,7 @@ module TestImport
 
 import Application           (makeFoundation, makeLogWare)
 import ClassyPrelude         as X
-import Database.Persist      as X hiding (get)
+import Database.Persist      as X hiding (get, delete, deleteBy)
 import Database.Persist.Sql  (SqlPersistM, SqlBackend, runSqlPersistMPool, rawExecute, rawSql, unSingle, connEscapeName)
 import Foundation            as X
 import Model                 as X

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -11,7 +11,7 @@ import Foundation            as X
 import Model                 as X
 import Test.Hspec            as X
 import Text.Shakespeare.Text (st)
-import Yesod.Default.Config2 (ignoreEnv, loadAppSettings)
+import Yesod.Default.Config2 (ignoreEnv, loadYamlSettings)
 import Yesod.Test            as X
 import LoadEnv (loadEnvFrom)
 
@@ -26,7 +26,7 @@ runDBWithApp app query = runSqlPersistMPool query (appConnPool app)
 withApp :: SpecWith (TestApp App) -> Spec
 withApp = before $ do
     loadEnvFrom ".env.test"
-    settings <- loadAppSettings
+    settings <- loadYamlSettings
         ["config/settings.yml"]
         []
         ignoreEnv

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -11,7 +11,7 @@ import Foundation            as X
 import Model                 as X
 import Test.Hspec            as X
 import Text.Shakespeare.Text (st)
-import Yesod.Default.Config2 (ignoreEnv, loadYamlSettings)
+import Yesod.Default.Config2 (useEnv, loadYamlSettings)
 import Yesod.Test            as X
 import LoadEnv (loadEnvFrom)
 
@@ -29,7 +29,7 @@ withApp = before $ do
     settings <- loadYamlSettings
         ["config/settings.yml"]
         []
-        ignoreEnv
+        useEnv
     foundation <- makeFoundation settings
     wipeDB foundation
     logWare <- liftIO $ makeLogWare foundation


### PR DESCRIPTION
By adding a Handler test, much more of the architecture is exercised compared to the unit tests like the tests for `Croniker.UrlParser`.

Fix these issues:

* Tell `loadYamlSettings` to use the env, rather than ignoring it
* Set required environment variables in tests
* Hide conflicting test imports
* Add `load-env` to test dependencies in the cabal file