### PR TITLE
Add dummy authentication for tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,3 +4,4 @@ LOG_LEVEL=debug
 SKIP_COMBINING=true
 TWITTER_CONSUMER_KEY=twitter_consumer_key
 TWITTER_CONSUMER_SECRET=twitter_consumer_secret
+USE_DUMMY_AUTH=true

--- a/Model/User.hs
+++ b/Model/User.hs
@@ -9,9 +9,8 @@ import Import.NoFoundation
 import Data.Time.Calendar (addDays)
 import Data.Time.Zones.All (TZLabel(Etc__UTC))
 
-authenticateUser :: AuthId m ~ UserId => Creds m -> DB (AuthenticationResult m)
-authenticateUser Creds{credsExtra} = do
-    let mTwitterUserId = lookup "user_id" credsExtra
+authenticateUser :: AuthId m ~ UserId => Maybe Text -> [(Text, Text)] -> DB (AuthenticationResult m)
+authenticateUser mTwitterUserId credsExtra = do
     muser <- maybe (return Nothing) (getBy . UniqueUser) mTwitterUserId
     case muser of
         Nothing -> createUser (credsToUser credsExtra)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,7 @@ skip-combining: "_env:SKIP_COMBINING:false"
 database-url: "_env:DATABASE_URL:postgres://croniker:croniker@localhost:5432/croniker_development"
 database-pool-size: "_env:DATABASE_POOL_SIZE:10"
 mutable-static: "_env:MUTABLE_STATIC:false"
+use-dummy-auth: "_env:USE_DUMMY_AUTH:false"
 
 # NB: If you need a numeric value (e.g. 123) to parse as a String, wrap it in single quotes (e.g. "_env:PGPASS:'123'")
 # See https://github.com/yesodweb/yesod/wiki/Configuration#parsing-numeric-values-as-strings

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -158,6 +158,8 @@ test-suite test
 
     other-modules: Croniker.MonikerNormalizationSpec
                  , Croniker.UrlParserSpec
+                 , Handler.RootSpec
+                 , TestImport
 
     extensions: TemplateHaskell
                 QuasiQuotes
@@ -176,6 +178,8 @@ test-suite test
                 ViewPatterns
                 TupleSections
 
+                NamedFieldPuns
+
     build-depends: base
                  , croniker
                  , yesod-test >= 1.5.0.1 && < 1.6
@@ -193,3 +197,4 @@ test-suite test
                  , aeson
                  , text >= 0.11 && < 2.0
                  , load-env
+                 , tz

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -55,6 +55,8 @@ data AppSettings = AppSettings
     -- ^ Perform no stylesheet/script combining
     , appLogLevel               :: LogLevel
     -- ^ The LogLevel to use
+    , appUseDummyAuth :: Bool
+    -- ^ Use dummy authentication? (Only set in tests.)
     }
 
 instance FromJSON AppSettings where
@@ -81,6 +83,7 @@ instance FromJSON AppSettings where
         appMutableStatic          <- o .:? "mutable-static"   .!= defaultDev
         appSkipCombining          <- o .: "skip-combining"
         appLogLevel               <- parseLogLevel <$> o .: "log-level"
+        appUseDummyAuth           <- o .: "use-dummy-auth"
 
         return AppSettings {..}
         where

--- a/test/Handler/RootSpec.hs
+++ b/test/Handler/RootSpec.hs
@@ -5,6 +5,8 @@ module Handler.RootSpec
 
 import TestImport
 
+import Data.Time.Zones.All (TZLabel(..))
+
 main :: IO ()
 main = hspec spec
 
@@ -17,3 +19,18 @@ spec = withApp $ do
 
                 statusIs 200
                 bodyContains "Schedule changes to your Twitter name with Croniker"
+
+        describe "when signed in" $ do
+            it "shows the profile form" $ do
+                let user = buildUser
+                void $ runDB $ insert user
+                loginAs user
+
+                get RootR
+                void $ followRedirect
+
+                bodyContains "gabebw"
+                bodyContains "Defaults to the next available date"
+
+buildUser :: User
+buildUser = User "1" "gabebw" "token123" "secret123" Etc__UTC True

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -56,3 +56,13 @@ getTables = do
     |] []
 
     return $ map unSingle tables
+
+loginAs :: User -> YesodExample App ()
+loginAs User{userTwitterUserId} = do
+    get RootR
+
+    request $ do
+        setMethod "POST"
+        addTokenFromCookie
+        addPostParam "ident" userTwitterUserId
+        setUrl ("/auth/page/dummy" :: Text)


### PR DESCRIPTION
When `$USE_DUMMY_AUTH` is set to `"true"`, Croniker will use `Yesod.Auth.Dummy` instead of Twitter authentication.

`Yesod.Auth.Dummy` works by setting the `credsIdent` field of to whatever you give it.

Previously, the entire `Creds` instance was passed to `authenticateUser`, which then pulled out the Twitter username from the `credsExtra` field. Dummy authentication does not set the `credsExtra` field, it only sets the `credsIdent` field. Thus, some authentication handling had to move up from `authenticateUser` into `authenticate`, which now pulls out different `Creds` fields depending on what kind of authentication is being done.

These links were very helpful while figuring this out:

* https://robots.thoughtbot.com/on-auth-and-tests-in-yesod
* https://www.stackage.org/haddock/lts-6.3/yesod-test-1.5.1.1/Yesod-Test.html