### PR TITLE
Build the timezone form in a much nicer way

### DIFF
--- a/Handler/UpdateUser.hs
+++ b/Handler/UpdateUser.hs
@@ -21,13 +21,10 @@ postUpdateUserR userId = do
             redirect RootR
 
 timezoneForm :: User -> Form User
-timezoneForm User{..} = renderDivs $ User
-       <$> pure userTwitterUserId
-       <*> pure userTwitterUsername
-       <*> pure userTwitterOauthToken
-       <*> pure userTwitterOauthTokenSecret
-       <*> areq (selectFieldList selectTZs) "" Nothing
-       <*> pure False
+timezoneForm user = renderDivs $ setTimezone
+    <$> areq (selectFieldList selectTZs) "" Nothing
     where
         selectTZs :: [(Text, TZLabel)]
         selectTZs = map (\tzlabel -> (b2t $ toTZName tzlabel, tzlabel)) [Africa__Abidjan .. Root__WET]
+
+        setTimezone tzLabel = user { userTzLabel = tzLabel }


### PR DESCRIPTION
Instead of pulling apart a User only to put it back together again almost the same way, we can use record syntax to set only the User data that's changing.

Thank you @tonyd256 for pointing this out!

Fixes #72.