### PR TITLE
Use plural SQL table names

### DIFF
--- a/config/models
+++ b/config/models
@@ -5,7 +5,7 @@
 -- Name json
 -- instead of
 -- Name
-User
+User sql=users
     twitterUserId Text
     twitterUsername Text
     twitterOauthToken Text
@@ -15,7 +15,7 @@ User
     publicRssFeed Bool default=False
     UniqueUser twitterUserId
     deriving Typeable Show
-Profile
+Profile sql=profiles
     moniker Text Maybe
     date Day
     userId UserId

--- a/migrations/plural-tables-for-user-and-profile.sql
+++ b/migrations/plural-tables-for-user-and-profile.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user" RENAME TO users;
+ALTER TABLE "profile" RENAME TO profiles;


### PR DESCRIPTION
The `user` table in PostgreSQL is a special table, so a database with a `user` table must reference it as `"user"`, e.g. `SELECT * FROM "user"`.

This is pretty annoying, and the easiest workaround is to rename the table to `users` (plural). For consistency, make the `profiles` table plural too.