### PR TITLE
Add created_at/updated_at fields to all tables

### DIFF
--- a/config/models
+++ b/config/models
@@ -13,6 +13,8 @@ User sql=users
     tzLabel TZLabel default='Etc/UTC'
     choseTimezone Bool default=False
     publicRssFeed Bool default=False
+    createdAt UTCTime default=now() MigrationOnly
+    updatedAt UTCTime default=now() MigrationOnly
     UniqueUser twitterUserId
     deriving Typeable Show
 Profile sql=profiles
@@ -22,5 +24,7 @@ Profile sql=profiles
     picture Text Maybe
     description Text Maybe
     sent Bool default=False
+    createdAt UTCTime default=now() MigrationOnly
+    updatedAt UTCTime default=now() MigrationOnly
     UniqueUserDate userId date
     deriving Show

--- a/migrations/users-profiles-date-triggers.sql
+++ b/migrations/users-profiles-date-triggers.sql
@@ -1,0 +1,12 @@
+-- Define the function to set the "updated_at" column
+CREATE OR REPLACE FUNCTION set_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- Create triggers
+CREATE TRIGGER set_users_updated_at BEFORE UPDATE ON "users" FOR EACH ROW EXECUTE PROCEDURE set_updated_at_column();
+CREATE TRIGGER set_profiles_updated_at BEFORE UPDATE ON "profiles" FOR EACH ROW EXECUTE PROCEDURE set_updated_at_column();


### PR DESCRIPTION
The `MigrationOnly` notation in `config/models` means that Haskell code will entirely ignore the field (except to create it when the app starts up). It's present in the database, but not used at all in Yesod. This is perfect for `created_at` and `updated_at`, which are set automatically via (respectively) a default value and a database trigger.

`MigrationOnly` docs: https://github.com/yesodweb/persistent/wiki/Persistent-entity-syntax#migrationonly

Fixes #77.