### PR TITLE
Handle Twitter's new Unicode rules for monikers

### DIFF
--- a/Form/Profile.hs
+++ b/Form/Profile.hs
@@ -5,7 +5,7 @@ module Form.Profile
 import Import
 
 import qualified Croniker.MonikerNormalization as CMN
-import qualified Croniker.MonikerFieldChecks as MonikerFieldChecks (allChecks)
+import qualified Croniker.MonikerFieldChecks as MonikerFieldChecks (runAllChecks)
 import Model.FormProfile (FormProfile(..))
 
 profileForm :: Day -> [Day] -> Day -> Form FormProfile
@@ -37,7 +37,7 @@ fs label attrs = FieldSettings
     }
 
 monikerField :: Field Handler Text
-monikerField = foldr check textField MonikerFieldChecks.allChecks
+monikerField = MonikerFieldChecks.runAllChecks textField
 
 dateField :: [Day] -> Day -> Field Handler Day
 dateField takenDays tomorrow = check (nothingScheduled takenDays) $ check (futureDate tomorrow) dayField

--- a/Form/Profile.hs
+++ b/Form/Profile.hs
@@ -5,7 +5,7 @@ module Form.Profile
 import Import
 
 import qualified Croniker.MonikerNormalization as CMN
-import qualified Croniker.UrlParser as CUP
+import qualified Croniker.MonikerFieldChecks as MonikerFieldChecks (allChecks)
 import Model.FormProfile (FormProfile(..))
 
 profileForm :: Day -> [Day] -> Day -> Form FormProfile
@@ -37,33 +37,7 @@ fs label attrs = FieldSettings
     }
 
 monikerField :: Field Handler Text
-monikerField = foldr check textField [
-                   doesNotContainUrl,
-                   doesNotContainTwitter,
-                   validWhitespace . CMN.normalize,
-                   validLength . CMN.normalize
-               ]
-
-doesNotContainTwitter :: Text -> Either Text Text
-doesNotContainTwitter moniker
-    | "twitter" `isInfixOf` toLower moniker = Left "Twitter doesn't allow monikers that contain \"Twitter\""
-    | otherwise = Right moniker
-
-doesNotContainUrl :: Text -> Either Text Text
-doesNotContainUrl moniker
-    | CUP.containsUrl moniker = Left "Twitter doesn't allow URLs in monikers"
-    | otherwise = Right moniker
-
-validLength :: Text -> Either Text Text
-validLength moniker
-    | length moniker == 0 = Left "Monikers cannot be blank"
-    | length moniker > 20 = Left "Twitter doesn't allow monikers longer than 20 characters"
-    | otherwise = Right moniker
-
-validWhitespace :: Text -> Either Text Text
-validWhitespace moniker
-    | any (`isInfixOf` moniker) ["\n", "\t"] = Left "Moniker cannot contain special whitespace characters"
-    | otherwise = Right moniker
+monikerField = foldr check textField MonikerFieldChecks.allChecks
 
 dateField :: [Day] -> Day -> Field Handler Day
 dateField takenDays tomorrow = check (nothingScheduled takenDays) $ check (futureDate tomorrow) dayField

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -15,6 +15,7 @@ library
     hs-source-dirs: ., app, src
     exposed-modules: Application
                      Croniker.MonikerNormalization
+                     Croniker.MonikerFieldChecks
                      Croniker.Time
                      Croniker.Types
                      Croniker.UrlParser

--- a/src/Croniker/MonikerFieldChecks.hs
+++ b/src/Croniker/MonikerFieldChecks.hs
@@ -1,0 +1,38 @@
+module Croniker.MonikerFieldChecks
+    ( allChecks
+    )
+    where
+
+import Import
+
+import qualified Croniker.MonikerNormalization as CMN
+import Croniker.UrlParser (containsUrl)
+
+allChecks :: [Text -> Either Text Text]
+allChecks = [
+              doesNotContainUrl,
+              doesNotContainTwitter,
+              validWhitespace . CMN.normalize,
+              validLength . CMN.normalize
+            ]
+
+doesNotContainTwitter :: Text -> Either Text Text
+doesNotContainTwitter moniker
+    | "twitter" `isInfixOf` toLower moniker = Left "Twitter doesn't allow monikers that contain \"Twitter\""
+    | otherwise = Right moniker
+
+doesNotContainUrl :: Text -> Either Text Text
+doesNotContainUrl moniker
+    | containsUrl moniker = Left "Twitter doesn't allow URLs in monikers"
+    | otherwise = Right moniker
+
+validLength :: Text -> Either Text Text
+validLength moniker
+    | length moniker == 0 = Left "Monikers cannot be blank"
+    | length moniker > 20 = Left "Twitter doesn't allow monikers longer than 20 characters"
+    | otherwise = Right moniker
+
+validWhitespace :: Text -> Either Text Text
+validWhitespace moniker
+    | any (`isInfixOf` moniker) ["\n", "\t"] = Left "Moniker cannot contain special whitespace characters"
+    | otherwise = Right moniker

--- a/src/Croniker/MonikerFieldChecks.hs
+++ b/src/Croniker/MonikerFieldChecks.hs
@@ -1,20 +1,32 @@
 module Croniker.MonikerFieldChecks
-    ( allChecks
+    ( runAllChecks
     )
     where
 
 import Import
 
-import qualified Croniker.MonikerNormalization as CMN
+import Croniker.MonikerNormalization (normalize)
 import Croniker.UrlParser (containsUrl)
+import Data.Char (ord)
+
+runAllChecks :: Field Handler Text -> Field Handler Text
+runAllChecks field = foldr check field allChecks
 
 allChecks :: [Text -> Either Text Text]
 allChecks = [
+              containsValidUnicodeCombinations,
               doesNotContainUrl,
               doesNotContainTwitter,
-              validWhitespace . CMN.normalize,
-              validLength . CMN.normalize
+              validWhitespace . normalize,
+              validLength . normalize
             ]
+
+-- Twitter's actively working on a fix for this: https://twitter.com/bhaggs/status/767936253886992384
+-- After it's fixed, this check can be deleted.
+containsValidUnicodeCombinations :: Text -> Either Text Text
+containsValidUnicodeCombinations moniker
+    | validUnicodeCombinations moniker = Right moniker
+    | otherwise = Left "Twitter requires that emoji outside the Basic Multilingual Plane be accompanied by emoji in the BMP. You can fix this by adding a heart: \10084"
 
 doesNotContainTwitter :: Text -> Either Text Text
 doesNotContainTwitter moniker
@@ -36,3 +48,17 @@ validWhitespace :: Text -> Either Text Text
 validWhitespace moniker
     | any (`isInfixOf` moniker) ["\n", "\t"] = Left "Moniker cannot contain special whitespace characters"
     | otherwise = Right moniker
+
+-- Twitter only allows characters outside BMP when accompanied by characters
+-- _inside_ the BMP.
+validUnicodeCombinations :: Text -> Bool
+validUnicodeCombinations moniker = all insideBMP moniker ||
+    (any outsideBMP moniker && any insideBMP moniker)
+
+-- Is this character outside Unicode's Basic Multilingual Plane?
+outsideBMP :: Char -> Bool
+outsideBMP c = ord c >= 0xFFFF
+
+-- Is this character inside Unicode's Basic Multilingual Plane?
+insideBMP :: Char -> Bool
+insideBMP c = ord c < 0xFFFF

--- a/src/Croniker/MonikerNormalization.hs
+++ b/src/Croniker/MonikerNormalization.hs
@@ -14,12 +14,7 @@ normalize = T.strip . stripCharacters . removeDisallowedCharacters
 removeDisallowedCharacters :: Text -> Text
 removeDisallowedCharacters = filter (not . bad)
     where
-        bad c = c `elem` ['<', '>'] || fancyUnicodeWhitespace c || outsideBMP c
-
--- Is this character outside Unicode's Basic Multilingual Plane (which ends at
--- U+FEFF)?
-outsideBMP :: Char -> Bool
-outsideBMP c = ord c >= 0xFEFF
+        bad c = c `elem` ['<', '>'] || fancyUnicodeWhitespace c
 
 -- Is this character fancy Unicode whitespace?
 fancyUnicodeWhitespace :: Char -> Bool

--- a/test/Croniker/MonikerNormalizationSpec.hs
+++ b/test/Croniker/MonikerNormalizationSpec.hs
@@ -23,10 +23,22 @@ codepoint2text codepoint = T.singleton $ chr codepoint
 spec :: Spec
 spec = describe "Croniker.MonikerNormalization" $ do
     describe "normalize" $ do
-        it "allows emoji in the Basic Multilingual Plane" $ do
+        it "allows codepoints below U+FFFF" $ do
             let recyclingSymbol = codepoint2text 0x267B
             let t = recyclingSymbol `T.append` "hello"
 
+            normalize t `shouldBe` t
+
+        it "allows codepoints above U+FFFF" $ do
+            let astral_plane_char = codepoint2text 0x10000
+
+            let t = T.concat [
+                        astral_plane_char,
+                        "he",
+                        astral_plane_char,
+                        "llo",
+                        astral_plane_char
+                    ]
             normalize t `shouldBe` t
 
         forM_ [0x2028, 0x2029] $ \c -> do
@@ -54,18 +66,6 @@ spec = describe "Croniker.MonikerNormalization" $ do
             it (printf "strips U+%X from the middle of the moniker" c) $ do
                 let t = T.concat ["he", codepoint2text c, "llo"]
                 normalize t `shouldBe` "hello"
-
-        it "strips chars above U+FEFF from the moniker" $ do
-            let astral_plane_char = codepoint2text 0x10000
-
-            let t = T.concat [
-                        astral_plane_char,
-                        "he",
-                        astral_plane_char,
-                        "llo",
-                        astral_plane_char
-                    ]
-            normalize t `shouldBe` "hello"
 
         it "removes leading whitespace from the moniker" $ do
             let t = "\t\n  hello"

--- a/test/Croniker/MonikerNormalizationSpec.hs
+++ b/test/Croniker/MonikerNormalizationSpec.hs
@@ -24,8 +24,8 @@ spec :: Spec
 spec = describe "Croniker.MonikerNormalization" $ do
     describe "normalize" $ do
         it "allows emoji in the Basic Multilingual Plane" $ do
-            let recycling_symbol = codepoint2text 0x267B
-            let t = recycling_symbol `T.append` "hello"
+            let recyclingSymbol = codepoint2text 0x267B
+            let t = recyclingSymbol `T.append` "hello"
 
             normalize t `shouldBe` t
 


### PR DESCRIPTION
Twitter requires that monikers with codepoints above the Basic Multilingual Plane (> U+FFFF, a.k.a. the "astral planes") include at least one codepoint that is within the BMP.

Croniker now displays an error message for monikers that are entirely astral plane codepoints, and recommends adding :heart: (U+2764, well within the BMP and friendly to boot).

Croniker also no longer removes all astral codepoints from monikers, since they are allowed, as long as they have a BMP companion.

It's worth noting that Twitter is working on a fix to allow all-astral-plane monikers: https://twitter.com/bhaggs/status/767936253886992384. When that ships, the `containsValidUnicodeCombinations` method can be deleted entirely.