### PR TITLE
Twitter allows astral codepoints by themselves

### DIFF
--- a/src/Croniker/MonikerFieldChecks.hs
+++ b/src/Croniker/MonikerFieldChecks.hs
@@ -7,26 +7,17 @@ import Import
 
 import Croniker.MonikerNormalization (normalize)
 import Croniker.UrlParser (containsUrl)
-import Data.Char (ord)
 
 runAllChecks :: Field Handler Text -> Field Handler Text
 runAllChecks field = foldr check field allChecks
 
 allChecks :: [Text -> Either Text Text]
 allChecks = [
-              containsValidUnicodeCombinations,
               doesNotContainUrl,
               doesNotContainTwitter,
               validWhitespace . normalize,
               validLength . normalize
             ]
-
--- Twitter's actively working on a fix for this: https://twitter.com/bhaggs/status/767936253886992384
--- After it's fixed, this check can be deleted.
-containsValidUnicodeCombinations :: Text -> Either Text Text
-containsValidUnicodeCombinations moniker
-    | validUnicodeCombinations moniker = Right moniker
-    | otherwise = Left "Twitter requires that emoji outside the Basic Multilingual Plane be accompanied by emoji in the BMP. You can fix this by adding a heart: \10084"
 
 doesNotContainTwitter :: Text -> Either Text Text
 doesNotContainTwitter moniker
@@ -48,17 +39,3 @@ validWhitespace :: Text -> Either Text Text
 validWhitespace moniker
     | any (`isInfixOf` moniker) ["\n", "\t"] = Left "Moniker cannot contain special whitespace characters"
     | otherwise = Right moniker
-
--- Twitter only allows characters outside BMP when accompanied by characters
--- _inside_ the BMP.
-validUnicodeCombinations :: Text -> Bool
-validUnicodeCombinations moniker = all insideBMP moniker ||
-    (any outsideBMP moniker && any insideBMP moniker)
-
--- Is this character outside Unicode's Basic Multilingual Plane?
-outsideBMP :: Char -> Bool
-outsideBMP c = ord c > 0xFFFF
-
--- Is this character inside Unicode's Basic Multilingual Plane?
-insideBMP :: Char -> Bool
-insideBMP c = ord c <= 0xFFFF


### PR DESCRIPTION
Twitter no longer requires that astral codepoints be accompanied by at least one non-astral codepoint.

Confirmed by Twitter: https://twitter.com/bhaggs/status/768464210938343425