### PR TITLE
Update the app to Stack resolver 8.0

### DIFF
--- a/Helper/HttpExceptionHandler.hs
+++ b/Helper/HttpExceptionHandler.hs
@@ -7,16 +7,18 @@ import Import
 import Network.HTTP.Client ()
 
 handleHttpException :: Either HttpException () -> Handler ()
-handleHttpException (Left e) = printHttpException e
+handleHttpException (Left (HttpExceptionRequest _ content)) = printHttpException content
 handleHttpException _ = return ()
 
-printHttpException :: MonadIO m => HttpException -> m ()
-printHttpException (StatusCodeException status headers _) = putStrLn $
+printHttpException :: MonadIO m => HttpExceptionContent -> m ()
+printHttpException (StatusCodeException response _) = putStrLn $
     "!!! Error! Status code "
     <> code
     <> " "
     <> errors
     where
+        status = responseStatus response
+        headers = responseHeaders response
         errors = tshow $ lookup "X-Response-Body-Start" headers
         code = tshow $ statusCode status
 

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -80,24 +80,24 @@ library
                  , classy-prelude-yesod          >= 0.10.2
                  , bytestring                    >= 0.9        && < 0.11
                  , text                          >= 0.11       && < 2.0
-                 , persistent                    >= 2.0        && < 2.3
-                 , persistent-postgresql         >= 2.1.1      && < 2.3
-                 , persistent-template           >= 2.0        && < 2.3
+                 , persistent                    >= 2.0        && <= 2.6
+                 , persistent-postgresql         >= 2.1.1      && <= 2.6
+                 , persistent-template           >= 2.0        && <= 2.6
                  , template-haskell
                  , shakespeare                   >= 2.0        && < 2.1
                  , hjsmin                        >= 0.1
                  , monad-control                 >= 0.3        && < 1.1
                  , wai-extra                     >= 3.0        && < 3.1
                  , yaml                          >= 0.8        && < 0.9
-                 , http-conduit                  >= 2.1        && < 2.2
-                 , directory                     >= 1.1        && < 1.3
+                 , http-conduit                  >= 2.1        && < 2.3
+                 , directory
                  , warp                          >= 3.0        && < 3.3
                  , data-default
                  , aeson                         >= 0.6
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4
                  , fast-logger                   >= 2.2        && < 2.5
-                 , wai-logger                    >= 2.2        && < 2.3
+                 , wai-logger
                  , file-embed
                  , safe
                  , unordered-containers
@@ -115,7 +115,7 @@ library
                  , lens-aeson
                  , network-uri
                  , tz
-                 , wreq-sb
+                 , wreq
                  , yesod-auth-oauth
                  , conduit-extra
                  , http-client

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -6,7 +6,7 @@
 -- declared in the Foundation.hs file.
 module Settings where
 
-import ClassyPrelude.Yesod
+import ClassyPrelude.Yesod hiding  (throw)
 import Control.Exception           (throw)
 import Data.Aeson                  (Result (..), fromJSON, withObject, (.!=),
                                     (.:?))

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available
-resolver: lts-6.4
+resolver: lts-8.0
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -9,11 +9,14 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver
 extra-deps:
+- authenticate-oauth-1.5.1.2@sha256:8bd5240fa7d54eea37a8ad94ac7eeda62b6d4f9c381efeb750a2853e24edc296
+- cabal-doctest-1.0.6@sha256:c0b4a5b1ff38d2867e7003b4be59f3bd7e8e204ab8c988d96d3a77472ae671cd
 - heroku-0.1.2.3
-- wreq-sb-0.4.0.0
-- yesod-auth-oauth-1.4.0.2
 - heroku-persistent-0.2.0
-- tld-0.3.0.0
+- load-env-0.2.0.2@sha256:1cc305683eea4791d632f3acbf0c3373cf760717eeaeef373c17a8709221ab93
+- tld-0.3.0.2
+- wreq-0.5.3.1@sha256:2221706cfea670b15d8d78f96b74900aa50b6dcbeb8b0d0fbf6482577f5a6bc4
+- yesod-auth-oauth-1.4.2
 
 # Override default flag values for local packages and extra-deps
 flags:

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -4,7 +4,7 @@ module TestImport
     ) where
 
 import Application           (makeFoundation, makeLogWare)
-import ClassyPrelude         as X
+import ClassyPrelude         as X hiding (Handler)
 import Database.Persist      as X hiding (get, delete, deleteBy)
 import Database.Persist.Sql  (SqlPersistM, SqlBackend, runSqlPersistMPool, rawExecute, rawSql, unSingle, connEscapeName)
 import Foundation            as X


### PR DESCRIPTION
We need GHC >=8.0.2 because lower versions can't build the app due to problems with macOS Sierra and linking.

Bugs:

* https://ghc.haskell.org/trac/ghc/ticket/13802, which links to
* https://ghc.haskell.org/trac/ghc/ticket/12479

LTS-8.0 is the first Stackage version that ships with GHC 8.0.2.

* Also, update code for new `StatusCodeException` type in http-client (which changed from version 0.4.29 in Stackage 6.4 to 0.5.5 in 8.0).
* Hide the new `ClassyPrelude.Handler` in favor of the standard `Foundation.Handler`