### PR TITLE
Create a new Dockerfile for deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,13 @@
+*.el
 *.hi
 *.keter
 *.o
 *.swp
 .DS_Store
 .cabal-sandbox
+.circleci
 .env
+.ghci
 .git
 !.git/refs/heads
 !.git/HEAD
@@ -20,5 +23,6 @@ docker-compose.yml
 env
 static/combined/
 static/tmp
+test/
 tmp
 yesod-devel/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,31 @@
-FROM thoughtbot/heroku-haskell-stack:lts-6.3
+FROM fpco/stack-build:lts-8.0
+
+# Everything will be put in this directory
+RUN mkdir -p /app/croniker
+WORKDIR /app/croniker
+
+COPY stack.yaml .
+COPY *.cabal .
+
+# Install GHC in its own layer so it gets cached
+RUN stack setup --install-ghc
+
+RUN stack install yesod-bin
+RUN stack install cabal-install
+
+RUN stack build --dependencies-only
+
+COPY . /app/croniker
+RUN stack --local-bin-path=. install
+
+# Clean up
+RUN rm -rf /app/croniker/.stack-work
+
+# Run the image as a non-root user for local testing, because Heroku does:
+#
+# > When deployed to Heroku, we also run your container as a non-root user
+# > (although we do not use the USER specified in the Dockerfile).
+RUN useradd -m myuser
+USER myuser
 
 CMD ./croniker

--- a/bin/deploy
+++ b/bin/deploy
@@ -15,16 +15,16 @@ if [ "$old_ref" = "$new_ref" ]; then
   exit 0
 fi
 
-if [ "$(uname)" = "Darwin" ]; then
-  if [ "$(docker-machine status default)" != "Running" ]; then
-      docker-machine start default
-  fi
-
-  eval "$(docker-machine env default)"
+if [ "$(docker info --format '{{.OperatingSystem}}' 2>/dev/null)" != 'Docker for Mac' ]; then
+  # Docker for Mac is not running, or we're not on a Mac.
+  # Either way, quit.
+  echo "!! Can't connect to Docker. Please start Docker for Mac."
+  exit 1
 fi
 
 heroku container:login
-heroku container:push --remote "$1"
+heroku container:push web --remote "$1"
+heroku container:release web --remote "$1"
 heroku config:set DEPLOYED_GIT_SHA="$new_ref" --remote "$1"
 
 echo "Old SHA: $old_ref"

--- a/bin/setup
+++ b/bin/setup
@@ -27,10 +27,6 @@ if ! psql -l | egrep "${app}_test.*$app"; then
   createdb --owner="$app" "${app}_test" || true
 fi
 
-if ! heroku plugins | grep -Fq heroku-container-tools; then
-  heroku plugins:install heroku-container-tools
-fi
-
 heroku git:remote --remote staging --app croniker-staging
 heroku git:remote --remote production --app croniker-production
 

--- a/stack-bootstrap
+++ b/stack-bootstrap
@@ -1,1 +1,0 @@
-alex classy-prelude-yesod happy yesod-bin yesod


### PR DESCRIPTION
thoughtbot's heroku-haskell-stack Dockerfile [hasn't been updated in 3 years][0], so use FP Complete's up-to-date Dockerfiles. As part of this switch, remove the `stack-bootstrap` file, which was [only used by the heroku-haskell-stack Docker image][1].

Additionally, switch from Heroku's deprecated container tools plugin to the fully-supported [Heroku Container Registry][2].

[0]: https://github.com/thoughtbot/docker-heroku-haskell-stack
[1]: https://github.com/thoughtbot/docker-heroku-haskell-stack/blob/a4d9d05700d977f7e552824b65390f73860332eb/Dockerfile#L26-L28
[2]: https://devcenter.heroku.com/articles/container-registry-and-runtime