### PR TITLE
Use `authTwitterUsingUserID`

### DIFF
--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -4,7 +4,7 @@ import Import.NoFoundation
 import Database.Persist.Sql (ConnectionPool, runSqlPool)
 import Text.Hamlet          (hamletFile)
 import Text.Jasmine         (minifym)
-import Yesod.Auth.OAuth     (authTwitter)
+import Yesod.Auth.OAuth     (authTwitterUsingUserId)
 import Yesod.Auth.Dummy     (authDummy)
 import Yesod.Default.Util   (addStaticContentExternal)
 import Yesod.Core.Types     (Logger)
@@ -148,7 +148,7 @@ instance YesodAuth App where
     authPlugins app =
         case appUseDummyAuth $ appSettings app of
             True -> [authDummy]
-            False -> [authTwitter (twitterConsumerKey app) (twitterConsumerSecret app)]
+            False -> [authTwitterUsingUserId (twitterConsumerKey app) (twitterConsumerSecret app)]
 
     authHttpManager = getHttpManager
 


### PR DESCRIPTION
`authTwitter` is deprecated:

```
In the use of ‘authTwitter’ (imported from Yesod.Auth.OAuth):
Deprecated: "Use authTwitterUsingUserID instead"
```

(Yes, the deprecation message has a typo. I made an issue to fix it: https://github.com/yesodweb/yesod/pull/1567)

`authTwitter` authenticated using the user's _screenname_ (e.g. `@foobar`), which can change. `authTwitterUsingUserId` uses the user ID, which will never change.

Relevant issue: https://github.com/yesodweb/yesod/pull/1168