### PR TITLE
Use a Dockerfile that can actually run the app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,9 @@ RUN stack build --dependencies-only --no-test
 COPY . /app/croniker
 RUN stack --local-bin-path=. install --no-test
 
-FROM alpine:3.8
+FROM ubuntu:16.04
 
+RUN apt-get update && apt-get install -y libpq-dev
 RUN mkdir -p /app/croniker
 WORKDIR /app/croniker
 
@@ -35,7 +36,7 @@ COPY --from=fpco /app/croniker/all-profiles .
 # > When deployed to Heroku, we also run your container as a non-root user
 # > (although we do not use the USER specified in the Dockerfile).
 # - https://devcenter.heroku.com/articles/container-registry-and-runtime
-RUN adduser -D myuser
+RUN useradd -m myuser
 USER myuser
 
 CMD ./croniker


### PR DESCRIPTION
Alpine Linux is based on musl, while GHC-built binaries rely on glibc. Therefore there's a bunch of weird errors when trying to run the image, like "__sprintf_chk: symbol not found".

Therefore, use a glibc-based distribution like Ubuntu.

The resulting image is 332MB (Ubuntu) instead of 150MB (Alpine), but it can actually run the programs, which is a huge point in Ubuntu's favor.

Here's a glibc-related issue on Alpine Linux: https://github.com/gliderlabs/docker-alpine/issues/149