### PR TITLE
Upgrade to Yesod 1.6 and Stack resolver 13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       TWITTER_CONSUMER_SECRET: twitter_consumer_secret
 
     docker:
-    - image: fpco/stack-build:lts-10.10
+    - image: fpco/stack-build:lts-13.0
     - image: circleci/postgres:10.6
       environment:
         POSTGRES_USER: croniker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fpco/stack-build:lts-10.10 AS fpco
+FROM fpco/stack-build:lts-13.0 AS fpco
 
 # Everything will be put in this directory
 RUN mkdir -p /app/croniker

--- a/Handler/UpdateProfilesTask.hs
+++ b/Handler/UpdateProfilesTask.hs
@@ -5,7 +5,7 @@ module Handler.UpdateProfilesTask
 
 import Import
 
-import qualified Control.Exception.Lifted as EL
+import UnliftIO.Exception (try)
 import Croniker.Types (OauthCredentials(OauthCredentials), OauthReader, runOauthReader)
 
 import Model.Profile (allProfilesForUpdate)
@@ -29,7 +29,7 @@ updateAllProfiles = do
     mapM_ updateWithErrorHandling profiles
 
 updateWithErrorHandling :: Entity Profile -> Handler ()
-updateWithErrorHandling profile = EL.try (updateProfile profile)
+updateWithErrorHandling profile = try (updateProfile profile)
     >>= handleHttpException
 
 updateProfile :: Entity Profile -> Handler ()

--- a/Model/FormProfile.hs
+++ b/Model/FormProfile.hs
@@ -37,5 +37,5 @@ valuesArePresent FormProfile{profileMoniker, profilePicture, profileDescription}
 base64Bytes :: Maybe FileInfo -> Handler (Maybe Text)
 base64Bytes Nothing = return Nothing
 base64Bytes (Just fi) = do
-    fileBytes <- runResourceT $ fileSource fi $$ sinkLbs
+    fileBytes <- runConduit $ fileSource fi .| sinkLbs
     return $ Just $ base64Encode fileBytes

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -86,7 +86,6 @@ library
                  , template-haskell
                  , shakespeare                   >= 2.0        && < 2.1
                  , hjsmin                        >= 0.1
-                 , monad-control                 >= 0.3        && < 1.1
                  , wai-extra                     >= 3.0        && < 3.1
                  , yaml
                  , http-conduit                  >= 2.1        && < 2.4
@@ -119,10 +118,10 @@ library
                  , yesod-auth-oauth
                  , conduit-extra
                  , http-client
-                 , lifted-base
                  , tld
                  , yesod-newsfeed
                  , blaze-html
+                 , unliftio
 
 executable         croniker
     if flag(library-only)

--- a/croniker.cabal
+++ b/croniker.cabal
@@ -70,11 +70,11 @@ library
                 NamedFieldPuns
 
     build-depends: base                          >= 4          && < 5
-                 , yesod                         >= 1.4.1      && < 1.5
-                 , yesod-core                    >= 1.4.17     && < 1.5
-                 , yesod-auth                    >= 1.4.0      && < 1.5
-                 , yesod-static                  >= 1.4.0.3    && < 1.6
-                 , yesod-form                    >= 1.4.0      && < 1.5
+                 , yesod                         >= 1.4.1      && <= 1.7
+                 , yesod-core                    >= 1.4.17     && <= 1.7
+                 , yesod-auth                    >= 1.4.0      && <= 1.7
+                 , yesod-static                  >= 1.4.0.3    && <= 1.7
+                 , yesod-form                    >= 1.4.0      && <= 1.7
                  , classy-prelude                >= 0.10.2
                  , classy-prelude-conduit        >= 0.10.2
                  , classy-prelude-yesod          >= 0.10.2
@@ -88,8 +88,8 @@ library
                  , hjsmin                        >= 0.1
                  , monad-control                 >= 0.3        && < 1.1
                  , wai-extra                     >= 3.0        && < 3.1
-                 , yaml                          >= 0.8        && < 0.9
-                 , http-conduit                  >= 2.1        && < 2.3
+                 , yaml
+                 , http-conduit                  >= 2.1        && < 2.4
                  , directory
                  , warp                          >= 3.0        && < 3.3
                  , data-default
@@ -188,7 +188,7 @@ test-suite test
 
     build-depends: base
                  , croniker
-                 , yesod-test >= 1.5.0.1 && < 1.6
+                 , yesod-test >= 1.5.0.1 && < 1.7
                  , yesod-core
                  , yesod
                  , persistent

--- a/src/Application.hs
+++ b/src/Application.hs
@@ -198,5 +198,5 @@ handler :: Handler a -> IO a
 handler h = getAppSettings >>= makeFoundation >>= flip unsafeHandler h
 
 -- | Run DB queries
-db :: ReaderT SqlBackend (HandlerT App IO) a -> IO a
+db :: ReaderT SqlBackend (HandlerFor App) a -> IO a
 db = handler . runDB

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -46,7 +46,7 @@ data App = App
 mkYesodData "App" $(parseRoutesFile "config/routes")
 
 -- | A convenient synonym for creating forms.
-type Form x = Html -> MForm (HandlerT App IO) (FormResult x, Widget)
+type Form x = Html -> MForm (HandlerFor App) (FormResult x, Widget)
 
 -- Please see the documentation for the Yesod typeclass. There are a number
 -- of settings which can be configured by overriding methods here.

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -6,7 +6,7 @@
 -- declared in the Foundation.hs file.
 module Settings where
 
-import ClassyPrelude.Yesod hiding  (throw)
+import ClassyPrelude.Yesod
 import Control.Exception           (throw)
 import Data.Aeson                  (Result (..), fromJSON, withObject, (.!=),
                                     (.:?))

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available
-#
-# 10.10 is the latest resolver version that supports Yesod <1.6:
-# https://www.stackage.org/package/yesod-bin/snapshots
-#
-# Upgrading to Yesod 1.6 will require some work.
-resolver: lts-10.10
+resolver: lts-13.0
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -20,7 +15,7 @@ extra-deps:
 - heroku-persistent-0.2.0
 - load-env-0.2.0.2
 - tld-0.3.0.2
-- yesod-auth-oauth-1.4.2
+- yesod-auth-oauth-1.6.0.1
 
 # Override default flag values for local packages and extra-deps
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,6 +15,7 @@ extra-deps:
 - heroku-persistent-0.2.0
 - load-env-0.2.0.2
 - tld-0.3.0.2
+- unliftio-0.2.9.0
 - yesod-auth-oauth-1.6.0.1
 
 # Override default flag values for local packages and extra-deps


### PR DESCRIPTION
As part of this, switch to Stack resolver version 13.0 (the newest version).

* Allow newer http-conduit version (11.5 was the first to ship a version higher than 2.3.0: https://www.stackage.org/package/http-conduit/snapshots)
* Allow any Yaml version (I'm confident that all of the packages in each Stack LTS release will work well with whatever `yaml` package is included)
* `ClassyPrelude.Yesod` no longer exports `throw`, so there's no need to hide it
* The default implementations of `authHttpManager` and `loginHandler` seem to work fine, and the versions that were in the app now fail to compile, so just comment them out and use Yesod's default implementations.
* Use new-style Conduit code
  * The old `$$` operator is deprecated now. (Note that this is a warning, not an error.)
* Use new `HandlerFor` instead of `HandlerT`
  * Yesod 1.6 moved to `HandlerFor`:  https://www.snoyman.com/blog/2018/02/conduitpocalypse
  * (Note that this is a warning, not an error.)

---------

Switch to the `unliftio` package instead of `Control.Exception.Lifted`

Yesod no longer works with `Control.Exception.Lifted` (it doesn't have  instances for `MonadBaseControl` anymore).

The move away from `Control.Exception.Lifted` was announced here:  https://www.snoyman.com/blog/2018/02/conduitpocalypse

This blog post was very helpful for understanding how to use `unliftio`:  https://www.fpcomplete.com/blog/2017/07/announcing-new-unliftio-library

Because of `unliftio`, there's no longer any need for the `monad-control` or `lifted-base` packages.