### PR TITLE
Redirect correctly from unauthorized paths

### DIFF
--- a/croniker.cabal
+++ b/croniker.cabal
@@ -162,6 +162,7 @@ test-suite test
     other-modules: Croniker.MonikerFieldChecksSpec
                  , Croniker.UrlParserSpec
                  , Handler.FeedSpec
+                 , Handler.ProfileSpec
                  , Handler.RootSpec
                  , TestImport
 

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -154,6 +154,8 @@ instance YesodAuth App where
             True -> [authDummy]
             False -> [authTwitterUsingUserId (twitterConsumerKey app) (twitterConsumerSecret app)]
 
+    loginHandler = liftHandler $ redirect RootR
+
 isSignedIn :: Handler AuthResult
 isSignedIn = do
     maid <- maybeAuthId

--- a/test/Handler/FeedSpec.hs
+++ b/test/Handler/FeedSpec.hs
@@ -67,7 +67,8 @@ spec = withApp $ do
                 get $ FeedR userId
 
                 statusIs 303
-                assertHeader "Location" "/auth/login"
+                void followRedirect
+                assertHeader "Location" "/"
 
         describe "when signed in as that user" $ do
             it "displays the feed" $ do

--- a/test/Handler/ProfileSpec.hs
+++ b/test/Handler/ProfileSpec.hs
@@ -1,0 +1,23 @@
+module Handler.ProfileSpec
+    ( main
+    , spec
+    ) where
+
+import TestImport
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = withApp $ do
+    describe "Visiting the profile path" $ do
+        describe "when signed out" $ do
+            it "redirects to / (eventually)" $ do
+                get ProfileR
+
+                assertHeader "Location" "/auth/login"
+                void followRedirect
+                assertHeader "Location" "/"
+                void followRedirect
+
+                assertNoHeader "Location"


### PR DESCRIPTION
Because of the change to `loginHandler` in eb303cb080b0652c8df7926d69d4920550db571e, visiting a page the requires authentication (like `/profiles`) when signed out redirects to `/auth/login`, which is an ugly unstyled page.

Instead, we want to redirect to `/`, which will show a pretty sign-in button to signed-out users.