### PR TITLE
Only save the Docker cache when it changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,18 @@ commands:
 
     steps:
       - run:
+          name: Set $DOCKER_CACHE_FOUND variable
+          command: |
+            if [[ -d ~/docker-cache ]]; then
+              export DOCKER_CACHE_FOUND=true
+            else
+              export DOCKER_CACHE_FOUND=false
+            fi
+      - run:
+          name: Show value of $DOCKER_CACHE_FOUND
+          command:
+            $DOCKER_CACHE_FOUND && echo "Found" || echo "Not found"
+      - run:
           # The cache directory might not exist if:
           # 1) The Dockerfile changed, invalidating the cache, and thus the
           #    `restore_cache` didn't do anything
@@ -40,11 +52,12 @@ commands:
               << parameters.arguments >> \
               .
       - run:
-          name: Save Docker cache for << parameters.tag >>
+          name: Save new Docker cache for << parameters.tag >>
           command: |
-            docker save \
-              --output ~/docker-cache/<< parameters.cache_path >> \
-              << parameters.tag >>
+            $DOCKER_CACHE_FOUND ||
+              docker save \
+                --output ~/docker-cache/<< parameters.cache_path >> \
+                << parameters.tag >>
 
   push_to_heroku:
     parameters:


### PR DESCRIPTION
The Docker cache (stored in `~/docker-cache/`) is saved to Circle's cache using a cache key based on the Dockerfile. When the Dockerfile changes, there's a new cache key, and no cache from a previous build is found. When the Dockerfile doesn't change, the cache key is the same as some previous build, and the cache is restored.

Thus, it follows that if the cache was restores, we _should not_ write to `~/docker-cache/` (with `docker save`) at all, because we'd be writing exactly the same data that already exists.

We should only `docker save` if there is _no_ cache, because it means the Dockerfile changed and there's something new to save.

`docker save` can take quite a while: around 8 minutes for the `croniker:fpco` image (here's a representative build: https://circleci.com/gh/gabebw/croniker/334).

By just not doing that, we save about 8 minutes for every build that uses the cache.

It's worth noting that I also tried gzipping the Docker cache files. Circle's "Restoring cache" step takes 5-6 minutes because the cache is 4.1GB(!), and I thought that perhaps gzip would shrink that down and save on download time. It did cut down on that step's time, which went from 5.5 to 2.5 minutes (https://circleci.com/gh/gabebw/croniker/328). (It only shrank the image from 4.1GB to 4.0GB, oddly enough.) However, gzipping added 9.5 minutes, meaning that it took 7 minutes longer (-2.5 + 9.5) to do a build, for a net loss.